### PR TITLE
Fix example config file in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ Config file is a JSON-encoded object with the following fields (see ``/examples/
 
 ``` js
 {
-      server: 'en.wikipedia.org',  // host name of MediaWiki-powered site
-      path: '/w',                  // path to api.php script
-      debug: false,                // is more verbose when set to true
-      username: 'foo',             // account to be used when logIn is called (optional)
-      password: 'bar'              // password to be used when logIn is called (optional)
+      "server": "en.wikipedia.org",  // host name of MediaWiki-powered site
+      "path": "/w",                  // path to api.php script
+      "debug": false,                // is more verbose when set to true
+      "username": "foo",             // account to be used when logIn is called (optional)
+      "password": "bar"              // password to be used when logIn is called (optional)
 }
 ```
 ## Making direct API calls


### PR DESCRIPTION
Change the example config file in README.md to be JSON encoded. The example config file as it was would throw an error if used verbatim.
