### PR TITLE
reenable cookies in request so login will work again

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -6,7 +6,7 @@ module.exports = (function() {
 	var VERSION = require('../package').version;
 
 	// @see https://github.com/mikeal/request
-	var request = require('request').defaults({jar: true});
+	var request = require('request');
 
 	// import deferred-js
 	// @see https://github.com/heavylifters/deferred-js
@@ -21,6 +21,7 @@ module.exports = (function() {
 		this.server = options.server;
 		this.path = options.path;
 		this.proxy = options.proxy;
+		this.jar = request.jar(); // create new cookie jar for each instance
 
 		this.debug = options.debug;
 
@@ -47,6 +48,7 @@ module.exports = (function() {
 			options = {
 				method: method || 'GET',
 				proxy: this.proxy || false,
+				jar: this.jar,
 				headers: {
 					'User-Agent': this.userAgent
 				}


### PR DESCRIPTION
Cookies are now off by default in the current version of the request module:
https://github.com/mikeal/request/pull/587

As a result, login no longer works. This reenables it.
