### PR TITLE
allow extra parameters for upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ Returns entries from recent changes (starting from a given point)
 
 Returns entries from [QueryPage-based special pages](http://www.mediawiki.org/wiki/API:Querypage)
 
-### bot.upload(filename, content, summary, callback)
+### bot.upload(filename, content, summary _/* or extraParams */_, callback)
 
 Uploads a given raw content as a File:[filename] - [read more](http://www.mediawiki.org/wiki/API:Upload)
 
-### bot.uploadByUrl(filename, url, summary, callback) 
+### bot.uploadByUrl(filename, url, summary _/* or extraParams */_, callback)
 
 Uploads a given external resource as a File:[filename]
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -436,22 +436,32 @@ module.exports = (function() {
 			});
 		},
 
-		upload: function(filename, content, summary, callback) {
-			var self = this;
+		upload: function(filename, content, extraParams, callback) {
+			var self = this,
+				params = {
+					action: 'upload',
+					ignorewarnings: '',
+					filename: filename,
+					file: (typeof content === 'string') ? new Buffer(content, 'binary') : content,
+					text: ''
+				},
+				key;
+
+			if (typeof extraParams == 'object') {
+				for (key in extraParams) {
+					params[key] = extraParams[key];
+				}
+			}
+			else { // it's summary (comment)
+				params.comment = extraParams;
+			}
 
 			// @see http://www.mediawiki.org/wiki/API:Upload
 			this.getToken('File:' + filename, 'edit', function(token) {
 				self.api.log('Uploading ' + (content.length/1024).toFixed(2) + ' kB as File:' + filename + '...');
 
-				self.api.call({
-					action: 'upload',
-					ignorewarnings: '',
-					filename: filename,
-					file: (typeof content === 'string') ? new Buffer(content, 'binary') : content,
-					text: '',
-					comment: summary,
-					token: token
-				}, function(data) {
+				params.token = token;
+				self.api.call(params, function(data) {
 					if (data && data.result && data.result === 'Success') {
 						callback && callback(data);
 					}


### PR DESCRIPTION
There was no way to send (for example) the `text` parameter in `bot.upload()`
or `bot.uploadByUrl()`, so I modified it to allow sending an object in place
of summary (comment), which will then be added to the parameters sent with
the request.
