### PR TITLE
+assertions, +-whitespace, +documentation, -extra commas, +strict equal

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -86,6 +86,32 @@ module.exports = (function() {
 			this.options[key] = val;
 		},
 
+		/**
+		 * Adds assertions to request parameters
+		 *
+		 * @param {Object} params Request parameters to add assertions to
+		 * @return {Object} The (possibly) augmented params object. Note that the input is also changed due to the nature of JavaScript object handling.
+		 */
+		addAssertions: function(params) {
+			var assertions = this.options.assertions;
+
+			if (assertions) {
+				params.assert = assertions;
+			}
+			return params;
+		},
+
+		/**
+		 * Adds assertions to request parameters and calls the API
+		 *
+		 * @param {Object} params request parameters
+		 * @param {Function} callback function to be invoked upon successful API request
+		 * @return {string} method used for the request ['GET'|'POST']. Note that some API modules require POST requests.
+		 */
+		callApiWithAssertions: function(params, callback, method) {
+			return this.api.call(this.addAssertions(params), callback, method);
+		},
+
 		logIn: function(username, password, callback /* or just callback */) {
 			var self = this;
 
@@ -104,9 +130,9 @@ module.exports = (function() {
 			this.api.call({
 				action: 'login',
 				lgname: username,
-				lgpassword: password,
+				lgpassword: password
 			}, function(data) {
-				if (data.result == 'NeedToken') {
+				if (data.result === 'NeedToken') {
 					var token = data.token;
 
 					self.log('Got token ' + token);
@@ -116,7 +142,7 @@ module.exports = (function() {
 						action: 'login',
 						lgname: username,
 						lgpassword: password,
-						lgtoken: token,
+						lgtoken: token
 					}, function(data) {
 						if (typeof data.lgusername !== 'undefined') {
 							self.log('Logged in as ' + data.lgusername);
@@ -225,7 +251,7 @@ module.exports = (function() {
 		getToken: function(title, action, callback) {
 			this.log("Getting " + action + " token (for " + title + ")...");
 
-			this.api.call({
+			this.callApiWithAssertions({
 				action: 'query',
 				prop: 'info',
 				intoken: action,
@@ -250,7 +276,7 @@ module.exports = (function() {
 			this.getToken(title, 'edit', function(token) {
 				self.log("Editing " + title + "...");
 
-				self.api.call({
+				self.callApiWithAssertions({
 					action: 'edit',
 					title: title,
 					text: content,
@@ -275,7 +301,7 @@ module.exports = (function() {
 			this.getToken(title, 'delete', function(token) {
 				self.log("Deleting " + title + "...");
 
-				self.api.call({
+				self.callApiWithAssertions({
 					action: 'delete',
 					title: title,
 					reason: reason,
@@ -338,7 +364,7 @@ module.exports = (function() {
 			this.getToken(from, 'move', function(token) {
 				self.log("Moving " + from + " to " + to + "...");
 
-				self.api.call({
+				self.callApiWithAssertions({
 					action: 'move',
 					from: from,
 					to: to,
@@ -433,7 +459,7 @@ module.exports = (function() {
 		},
 
 		expandTemplates: function(text, title, callback) {
-			this.api.call({
+			this.callApiWithAssertions({
 				action: 'expandtemplates',
 				text: text,
 				title: title,
@@ -451,7 +477,7 @@ module.exports = (function() {
 				'comments',
 				'user',
 				'flags',
-				'sizes',
+				'sizes'
 			];
 
 			this.api.call({
@@ -488,7 +514,7 @@ module.exports = (function() {
 				},
 				key;
 
-			if (typeof extraParams == 'object') {
+			if (typeof extraParams === 'object') {
 				for (key in extraParams) {
 					params[key] = extraParams[key];
 				}
@@ -502,7 +528,7 @@ module.exports = (function() {
 				self.log('Uploading %s kB as File:%s...', (content.length/1024).toFixed(2), filename);
 
 				params.token = token;
-				self.api.call(params, function(data) {
+				self.callApiWithAssertions(params, function(data) {
 					if (data && data.result && data.result === 'Success') {
 						callback && callback(data);
 					}
@@ -532,18 +558,18 @@ module.exports = (function() {
 					callback && callback((data && getFirstItem(data.pages).extlinks) || []);
 			});
 		},
-                
-                getBacklinks: function(title, callback) {
-                                this.api.call({
-                                        action: 'query',
-                                        list: 'backlinks',
-                                        blnamespace: 0,
-                                        bltitle: title,
-                                        bllimit: 5000
-                                }, function(data) {
-                                        callback((data && data.backlinks) || []);
-                        });
-                },
+
+		getBacklinks: function(title, callback) {
+			this.api.call({
+				action: 'query',
+				list: 'backlinks',
+				blnamespace: 0,
+				bltitle: title,
+				bllimit: 5000
+			}, function(data) {
+				callback((data && data.backlinks) || []);
+			});
+		},
 
 		// utils section
 


### PR DESCRIPTION
Assertions ensure that the bot is logged-in and/or flagged as bot while being logged-in. After this change, an option ``"assertions": "bot|user"`` is available for configuration.
Only adding assertions to requests changing content; one could consider enabling them for all requests, except login. Opinions?

We possibly want to make ``.addAssertions()`` private? Not sure, also open for discussion in this regard.

TAB-indention in ``.getBacklinks()``

JSDuck-documenting new methods.

Removed extra commas.

``data.result`` is always a ``string`` (never ``String``) so it's safe to use strict equal here.