### PR TITLE
Introduce getAllPages and getArticleRevisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Gets the list of all categories on a wiki
 
 ### bot.getAllPages(callback)
 
-Gets the list of all pages from the main namespace (excludes redirects)
+Gets the list of all pages from the main namespace (excludes redirects) - [read more](https://www.mediawiki.org/wiki/API:Allpages)
 
 ### bot.getPagesInCategory(category, callback)
 
@@ -164,6 +164,10 @@ Gets the list of pages by a given prefix - [read more](https://www.mediawiki.org
 ### bot.getArticle(title, callback)
 
 Gets article content and its meta data - [read more](http://www.mediawiki.org/wiki/API:Properties#revisions_.2F_rv)
+
+### bot.getArticleRevisions(title, callback)
+
+Gets all revisions of a given article - [read more](http://www.mediawiki.org/wiki/API:Revisions)
 
 ### bot.edit(title, content, summary, callback)
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Log-in using given credentials - [read more](http://www.mediawiki.org/wiki/API:L
 
 Gets the list of all categories on a wiki
 
+### bot.getAllPages(callback)
+
+Gets the list of all pages from the main namespace (excludes redirects)
+
 ### bot.getPagesInCategory(category, callback)
 
 Gets the list of pages in a given category - [read more](http://www.mediawiki.org/wiki/API:Properties#revisions_.2F_rv)

--- a/examples/allPages.js
+++ b/examples/allPages.js
@@ -1,0 +1,16 @@
+/**
+ * Example script getting the list of all pages
+ */
+'use strict';
+
+var bot = require('..'),
+	client = new bot({
+		server: 'poznan.wikia.com',
+		path: '',
+		debug: true
+	});
+
+client.getAllPages(function(err, pages) {
+	console.log('All pages: %d', pages.length);
+	console.log(JSON.stringify(pages.slice(0, 50)));
+});

--- a/examples/allPages.js
+++ b/examples/allPages.js
@@ -13,4 +13,11 @@ var bot = require('..'),
 client.getAllPages(function(err, pages) {
 	console.log('All pages: %d', pages.length);
 	console.log(JSON.stringify(pages.slice(0, 50)));
+
+	// get all revisions of a single article
+	var pageId = parseInt(pages[0].pageid, 10);
+
+	client.getArticleRevisions(pageId, function(err, revisions) {
+		console.log(JSON.stringify(revisions));
+	});
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -181,7 +181,7 @@ module.exports = (function() {
 			try {
 				data = JSON.parse(body);
 				info = data && data[actionName];
-				next = data && data['query-continue'] && data['query-continue'][params.list];
+				next = data && data['query-continue'] && data['query-continue'][params.list || params.prop];
 			}
 			catch(e) {
 				self.logger.error('Error parsing JSON response: %s',  body);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -58,7 +58,7 @@ module.exports = (function() {
 			proxy: options.proxy,
 			userAgent: options.userAgent,
 			concurrency: options.concurrency,
-			debug: (options.debug === true || env.DEBUG === '1'),
+			debug: (options.debug === true || env.DEBUG === '1')
 		});
 
 		this.version = this.api.version;
@@ -192,23 +192,21 @@ module.exports = (function() {
 			if(typeof prefix === 'function') {
 				callback = prefix;
 			}
-			this.api.call({
-				action: 'query',
-				list: 'allcategories',
-				acprefix : prefix || '',
-				aclimit: 5000
-			}, function(err, data, next){
-				var allCat = data.allcategories,
-					categories = [],
-					cat,
-					i = 0;
 
-				while(cat = allCat[i]) {
-					categories[i++] = cat['*'];
-				}
-
-				callback(err, categories, next && next.acfrom || false);
-			});
+			this.getAll(
+				{
+					action: 'query',
+					list: 'allcategories',
+					acprefix : prefix || '',
+					aclimit: 5000
+				},
+				function(data){
+					return data.allcategories.map(function(cat) {
+						return cat['*'];
+					});
+				},
+				callback
+			);
 		},
 
 		getUsers: function(data, callback){

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -5,6 +5,8 @@ module.exports = (function() {
 	'use strict';
 
 	var Api = require('./api'),
+		_ = require('underscore'),
+		async = require('async'),
 		fs = require('fs');
 
 	// get the object being the first key/value entry of a given object
@@ -97,6 +99,42 @@ module.exports = (function() {
 			return Math.random().toString().split('.').pop();
 		},
 
+		getAll: function(params, key, callback) {
+			var self = this,
+				res = [],
+				continueParams;
+
+			async.whilst(
+				function() {
+					// run as long as there's more data
+					return true;
+				},
+				function(callback) {
+					self.api.call(_.extend(params, continueParams), function(err, data, next) {
+						if (err) {
+							callback(err);
+						}
+						else {
+							// append batch data
+							res = res.concat(data[key]);
+
+							// more pages?
+							continueParams = next;
+							callback(next ? null : true);
+						}
+					});
+				},
+				function(err) {
+					if (err instanceof Error) {
+						callback(err);
+					}
+					else {
+						callback(null, res);
+					}
+				}
+			);
+		},
+
 		logIn: function(username, password, callback /* or just callback */) {
 			var self = this;
 
@@ -187,6 +225,20 @@ module.exports = (function() {
 			}, function(err, data){
 				callback(err, data && data.allusers || []);
 			});
+		},
+
+		getAllPages: function(callback) {
+			this.log("Getting all pages...");
+			this.getAll(
+				{
+					action: 'query',
+					list: 'allpages',
+					apfilterredir: 'nonredirects', // do not include redirects
+					aplimit: 5000
+				},
+				'allpages',
+				callback
+			);
 		},
 
 		getPagesInCategory: function(category, callback) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -116,7 +116,9 @@ module.exports = (function() {
 						}
 						else {
 							// append batch data
-							res = res.concat(data[key]);
+							var batchData = (typeof key === 'function') ? key(data) : data[key];
+
+							res = res.concat(batchData);
 
 							// more pages?
 							continueParams = next;
@@ -300,7 +302,36 @@ module.exports = (function() {
 				callback(null, content);
 			});
 		},
-		
+
+		getArticleRevisions: function(title, callback) {
+			var params = {
+				action: 'query',
+				prop: 'revisions',
+				rvprop: ['ids', 'timestamp', 'size', 'flags', 'comment', 'user'].join('|'),
+				rvdir: 'newer', // order by timestamp asc
+				rvlimit: 5000
+			};
+
+			// both page ID or title can be provided
+			if (typeof title === 'number') {
+				this.log("Getting revisions of article #" + title + "...");
+				params.pageids = title;
+			}
+			else {
+				this.log("Getting revisions of " + title + "...");
+				params.titles = title;
+			}
+
+			this.getAll(
+				params,
+				function(batch) {
+					var page = getFirstItem(batch.pages);
+					return page.revisions;
+				},
+				callback
+			);
+		},
+
 		search: function(keyword, callback) {
 			var params = {
 				action: 'query',

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -657,9 +657,7 @@ module.exports = (function() {
 			}
 
 			if (typeof extraParams === 'object') {
-				for (key in extraParams) {
-					params[key] = extraParams[key];
-				}
+				params = _.extend(params, extraParams);
 			}
 			else { // it's summary (comment)
 				params.comment = extraParams;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "async": "0.9.x",
     "diff": "1.3.x",
     "request": "2.45.x",
+    "underscore": "1.8.x",
     "winston": "0.8.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Introduce `getAll` helper for getting all results from paginated API response.

Use it in new `getAllPages` and `getArticleRevisions` functions and `getCategories`.