### PR TITLE
Travis: test using Node.js v0.10 and v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
-node_js: "0.10"
+sudo: false
+node_js:
+  - "0.12"
+  - "0.10"
 script: "npm test && npm run-script lint"


### PR DESCRIPTION
And use the new, container-based Travis infrastructure for testing

http://docs.travis-ci.com/user/migrating-from-legacy/