### PR TITLE
add function: getPagesInNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Gets the list of all pages from the main namespace (excludes redirects) - [read 
 
 Gets the list of pages in a given category - [read more](http://www.mediawiki.org/wiki/API:Properties#revisions_.2F_rv)
 
+### bot.getPagesInNamespace(namespace, callback)
+
+Gets the list of pages in a given namespace - [read more](http://www.mediawiki.org/wiki/API:Allpages)
+
 ### bot.getPagesByPrefix(prefix, callback)
 
 Gets the list of pages by a given prefix - [read more](https://www.mediawiki.org/wiki/API:Allpages)

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -265,17 +265,19 @@ module.exports = (function() {
 		},
 
 		getPagesInNamespace: function(namespace, callback) {
-				this.log("Getting pages in namespace " + namespace);
+			this.log("Getting pages in namespace " + namespace);
 
-				this.api.call({
-						action: 'query',
-						list: 'allpages',
-						apnamespace: namespace,
-						apfilterredir: 'nonredirects', // do not include redirects
-						aplimit: 5000
-				}, function(err, data) {
-						callback(err, data && data.allpages || []);
-				});
+			this.getAll(
+				{
+					action: 'query',
+					list: 'allpages',
+					apnamespace: namespace,
+					apfilterredir: 'nonredirects', // do not include redirects
+					aplimit: 5000
+				},
+				'allpages',
+				callback
+			);
 		},
 
 		getPagesByPrefix: function(prefix, callback) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -264,19 +264,19 @@ module.exports = (function() {
 			);
 		},
 
-        getPagesInNamespace: function(namespace, callback) {
-            this.log("Getting pages in namespace " + namespace);
+		getPagesInNamespace: function(namespace, callback) {
+				this.log("Getting pages in namespace " + namespace);
 
-            this.api.call({
-                action: 'query',
-                list: 'allpages',
-                apnamespace: namespace,
-                apfilterredir: 'nonredirects', // do not include redirects
-                aplimit: 5000
-            }, function(err, data) {
-                callback(err, data && data.allpages || []);
-            });
-        },
+				this.api.call({
+						action: 'query',
+						list: 'allpages',
+						apnamespace: namespace,
+						apfilterredir: 'nonredirects', // do not include redirects
+						aplimit: 5000
+				}, function(err, data) {
+						callback(err, data && data.allpages || []);
+				});
+		},
 
 		getPagesByPrefix: function(prefix, callback) {
 			this.log("Getting pages by " + prefix + " prefix...");

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -264,6 +264,20 @@ module.exports = (function() {
 			);
 		},
 
+        getPagesInNamespace: function(namespace, callback) {
+            this.log("Getting pages in namespace " + namespace);
+
+            this.api.call({
+                action: 'query',
+                list: 'allpages',
+                apnamespace: namespace,
+                apfilterredir: 'nonredirects', // do not include redirects
+                aplimit: 5000
+            }, function(err, data) {
+                callback(err, data && data.allpages || []);
+            });
+        },
+
 		getPagesByPrefix: function(prefix, callback) {
 			this.log("Getting pages by " + prefix + " prefix...");
 


### PR DESCRIPTION
Add a function to easily pull the pages from a given namespace. Example of use: 

    client.getPagesInNamespace(502, function(err, pages) {
        console.log('All pages: %d', pages.length);
        console.log(JSON.stringify(pages.slice(0, 50)));

        // get all revisions of a single article
        var pageId = parseInt(pages[0].pageid, 10);

        client.getArticleRevisions(pageId, function(err, revisions) {
            console.log(JSON.stringify(revisions));
        });
    });
