### PR TITLE
Fixed crash when trying to delete a page

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -471,7 +471,7 @@ module.exports = (function() {
 					return;
 				}
 
-				self.log("Deleting '%s' because '%s'...", title, because);
+				self.log("Deleting '%s' because '%s'...", title, reason);
 
 				self.api.call({
 					action: 'delete',
@@ -563,10 +563,10 @@ module.exports = (function() {
 				'groups',
 				'rights',
 				'ratelimits',
-				'editcount', 
+				'editcount',
 				'realname',
 				'email'
-			]; 
+			];
 
 			this.api.call({
 				action: 'query',
@@ -839,7 +839,7 @@ module.exports = (function() {
 					callback(err, (data && getFirstItem(data.pages).extlinks) || []);
 			});
 		},
-                
+
 		getBacklinks: function(title, callback) {
 			this.api.call({
 				action: 'query',


### PR DESCRIPTION
Hi there,

I'm getting an upload error when trying to delete a page on MediaWiki 1.25.2

This seems to be due to a misreferenced variable name. The pull-request fixes the problem for me.

All the best!
Simon

```
> ReferenceError: because is not defined
ReferenceError: because is not defined
    at c:\Development\mobo\node_modules\nodemw\lib\bot.js:474:54
    at c:\Development\mobo\node_modules\nodemw\lib\bot.js:419:5
    at Request._callback (c:\Development\mobo\node_modules\nodemw\lib\api.js:213:5)
    at Request.self.callback (c:\Development\mobo\node_modules\nodemw\node_modules\request\request.js:354:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (c:\Development\mobo\node_modules\nodemw\node_modules\request\request.js:1207:14)
    at emitOne (events.js:82:20)
    at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (c:\Development\mobo\node_modules\nodemw\node_modules\request\request.js:1153:12)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:893:12)
    at doNTCallback2 (node.js:430:9)
    at process._tickCallback (node.js:344:17)
```