### PR TITLE
GetArticleCategories fix

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -378,7 +378,7 @@ module.exports = (function() {
 					null,
 					(page.categories || []).map(function(cat) {
 						// { ns: 14, title: 'Kategoria:XX wiek' }
-						return cat.title.split(':')[1];
+                        return cat.title.substring(cat.title.indexOf(":")+1);
 					})
 				);
 			});

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -378,7 +378,7 @@ module.exports = (function() {
 					null,
 					(page.categories || []).map(function(cat) {
 						// { ns: 14, title: 'Kategoria:XX wiek' }
-                        return cat.title.substring(cat.title.indexOf(":")+1);
+						return cat.title.substring(cat.title.indexOf(":")+1);
 					})
 				);
 			});


### PR DESCRIPTION
With this approach, only the part before the first ":" gets removed.

It was an issue on fr.wiki, since certain categories have several ":"

[Catégorie:Wikipédia:Phénix](https://fr.wikipedia.org/wiki/Cat%C3%A9gorie:Wikip%C3%A9dia:Ph%C3%A9nix) is one of the many examples.