### PR TITLE
Nodemw is not forwarding the error messages from the MW API

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -445,12 +445,15 @@ module.exports = (function() {
 					summary: summary,
 					token: token
 				}, function(err, data) {
+
+					console.log('Edit failed: ' + err);
+
 					if (!err && data.result && data.result === "Success") {
 						self.log("Rev #%d created for '%s'", data.newrevid, data.title);
 						callback(null, data);
 					}
 					else {
-						callback(new Error('Edit failed'));
+						callback(new Error('Edit failed: ' + err));
 					}
 				}, 'POST');
 			});

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -445,9 +445,6 @@ module.exports = (function() {
 					summary: summary,
 					token: token
 				}, function(err, data) {
-
-					console.log('Edit failed: ' + err);
-
 					if (!err && data.result && data.result === "Success") {
 						self.log("Rev #%d created for '%s'", data.newrevid, data.title);
 						callback(null, data);


### PR DESCRIPTION
I've had some issues with my MW installation and nodemw did not return the reason why the edit failed. This will append the original error message to nodemw's error msg.

Best,
Simon