### PR TITLE
a quick and dirty fix to getToken

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -409,17 +409,13 @@ module.exports = (function() {
 
 			this.api.call({
 				action: 'query',
-				prop: 'info',
-				intoken: action,
-				titles: title
+				meta: 'tokens'
 			}, function(err, data) {
 				if (err) {
 					callback(err);
 					return;
 				}
-
-				var page = getFirstItem(data.pages),
-					token = page[ action + 'token'];
+				var token = data.tokens.csrftoken.toString();
 
 				if (!token) {
 					err = new Error('Can\'t get "' + action + '" token for "' + title + '" page!');


### PR DESCRIPTION
in newer versions of mediawiki action: " 'query', meta: 'tokens' " is required to get the token.