### PR TITLE
getToken: use new token API for MW 1.24+ sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Send an email to an user - [read more](http://www.mediawiki.org/wiki/API:Email)
 
 ### bot.getToken(title, action, callback)
 
-Returns token required for a number of MediaWiki API operations
+Returns token required for a number of MediaWiki API operations - [read more](https://www.mediawiki.org/wiki/API:Tokens_(action)) / [for MW 1.24+](https://www.mediawiki.org/wiki/API:Tokens)
 
 ### bot.whoami(callback)
 

--- a/examples/getToken.js
+++ b/examples/getToken.js
@@ -1,0 +1,26 @@
+/**
+ * Example script getting the edit token
+ */
+'use strict';
+
+var bot = require('..'),
+	wikia = new bot({
+		server: 'nordycka.wikia.com',
+		path: '',
+		debug: true
+	}),
+	wikipedia = new bot({
+		server: 'pl.wikipedia.org',
+		path: '/w',
+		debug: true
+	});
+
+wikia.getToken('Main_page', 'edit', function(err, token) {
+	if (err) wikia.log(err);
+	wikia.log('Wikia:', token);
+});
+
+wikipedia.getToken('Main_page', 'edit', function(err, token) {
+	if (err) wikipedia.log(err);
+	wikipedia.log('Wikipedia:', token);
+});

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -453,9 +453,11 @@ module.exports = (function() {
 						return;
 					}
 
-					token = useTokenApi
-						? data.tokens.csrftoken.toString() // MW 1.24+
-						: getFirstItem(data.pages)[ action + 'token']; // older MW version
+					if (useTokenApi) {
+						token = data.tokens.csrftoken.toString(); // MW 1.24+
+					} else {
+						token = getFirstItem(data.pages)[ action + 'token']; // older MW version
+					}
 
 					if (!token) {
 						var msg = raw.warnings.info['*'];

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -423,28 +423,49 @@ module.exports = (function() {
 		getToken: function(title, action, callback) {
 			this.log("Getting " + action + " token (for " + title + ")...");
 
-			this.api.call({
-				action: 'query',
-				prop: 'info',
-				intoken: action,
-				titles: title
-			}, (function(err, data, next, raw) {
-				if (err) {
-					callback(err);
-					return;
+			this.getMediaWikiVersion((function(err, version) {
+				var compare = require('node-version-compare'),
+					params,
+					useTokenApi = compare(version, '1.24.0') > -1;
+
+				// @see https://www.mediawiki.org/wiki/API:Tokens (for MW 1.24+)
+				if (useTokenApi) {
+					params = {
+						action: 'query',
+						meta: 'tokens',
+						type: 'csrf'
+					};
+				}
+				else {
+					params = {
+						action: 'query',
+						prop: 'info',
+						intoken: action,
+						titles: title
+					};
 				}
 
-				var page = getFirstItem(data.pages),
-					token = page[ action + 'token'];
+				this.api.call(params, (function(err, data, next, raw) {
+					var token;
 
-				if (!token) {
-					var msg = raw.warnings.info['*'];
-                                        this.log('getToken: ' + msg);
-					err = new Error('Can\'t get "' + action + '" token for "' + title + '" page - ' + msg);
-					token = undefined;
-				}
+					if (err) {
+						callback(err);
+						return;
+					}
 
-				callback(err, token);
+					token = useTokenApi
+						? data.tokens.csrftoken.toString() // MW 1.24+
+						: getFirstItem(data.pages)[ action + 'token']; // older MW version
+
+					if (!token) {
+						var msg = raw.warnings.info['*'];
+						this.log('getToken: ' + msg);
+						err = new Error('Can\'t get "' + action + '" token for "' + title + '" page - ' + msg);
+						token = undefined;
+					}
+
+					callback(err, token);
+				}).bind(this));
 			}).bind(this));
 		},
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -428,7 +428,7 @@ module.exports = (function() {
 				prop: 'info',
 				intoken: action,
 				titles: title
-			}, function(err, data) {
+			}, (function(err, data, next, raw) {
 				if (err) {
 					callback(err);
 					return;
@@ -438,12 +438,14 @@ module.exports = (function() {
 					token = page[ action + 'token'];
 
 				if (!token) {
-					err = new Error('Can\'t get "' + action + '" token for "' + title + '" page!');
+					var msg = raw.warnings.info['*'];
+                                        this.log('getToken: ' + msg);
+					err = new Error('Can\'t get "' + action + '" token for "' + title + '" page - ' + msg);
 					token = undefined;
 				}
 
 				callback(err, token);
-			});
+			}).bind(this));
 		},
 
 		edit: function(title, content, summary, minor, callback) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "async": "^2.0.0-rc.2",
     "diff": "^2.2.2",
     "jshint": "^2.9.1",
+    "node-version-compare": "^1.0.1",
     "request": "^2.69.0",
     "underscore": "1.8.x",
     "winston": "^2.2.0"


### PR DESCRIPTION
[Old API](https://www.mediawiki.org/wiki/API:Tokens_(action)) vs [a new one for MW 1.24+](https://www.mediawiki.org/wiki/API:Tokens) - as suggested in #91 by @lagleki

```
info:    Detected MediaWiki v1.19.24
debug:   API action: query
debug:   GET <http://nordycka.wikia.com/api.php?action=query&prop=info&intoken=edit&titles=Main_page&format=json>
info:    Detected MediaWiki v1.27.0
debug:   API action: query
debug:   GET <http://pl.wikipedia.org/w/api.php?action=query&meta=tokens&type=csrf&format=json>
```