### PR TITLE
getLog: handle filtering by both letype and leaction

### DIFF
--- a/examples/specialLog2csv.js
+++ b/examples/specialLog2csv.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Example script generating CSV file from Special:Log entries
+ *
+ * @see https://pl.wikipedia.org/w/api.php?action=help&modules=query%2Blogevents
  */
-
 const async = require('async'),
 	bot = require('..'),
 	client = new bot({
@@ -11,6 +12,7 @@ const async = require('async'),
 		debug: true
 	}),
 	logType = 'thanks';
+	//logType = 'review/approve';
 
 // @see https://github.com/caolan/async#whilsttest-fn-callback
 var start = '',

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -812,13 +812,24 @@ module.exports = (function() {
 		},
 
 		getLog(type, start, callback) {
-			this.api.call({
+			let params = {
 				action: 'query',
 				list: 'logevents',
-				letype: type,
 				lestart: start,
 				lelimit: API_LIMIT
-			}, function(err, data, next) {
+			};
+
+			if (type.indexOf('/') > 0) {
+				// Filter log entries to only this type.
+				params.leaction = type;
+			}
+			else {
+				// Filter log actions to only this action. Overrides letype. In the list of possible values,
+				// values with the asterisk wildcard such as action/* can have different strings after the slash (/).
+				params.letype = type;
+			}
+
+			this.api.call(params, function(err, data, next) {
 				if (next && next.lecontinue) {
 					// 20150101124329|22700494
 					next = next.lecontinue.split('|').shift();


### PR DESCRIPTION
[API docs](https://pl.wikipedia.org/w/api.php?action=help&modules=query%2Blogevents)

* **letype** - Filter log entries to only this type.
* **leaction** - Filter log actions to only this action. Overrides letype. In the list of possible values, values with the asterisk wildcard such as `action/*` can have different strings after the slash (/).

You can use `getLog` to get actions for both `thanks` and `review/approve` actions.