### PR TITLE
doEdit: do not wrap err object

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -517,7 +517,7 @@ module.exports = (function() {
 						callback(null, data);
 					}
 					else {
-						callback(new Error(`Edit failed: ${err}`));
+						callback(err);
 					}
 				}, 'POST');
 			});
@@ -714,7 +714,7 @@ module.exports = (function() {
 						callback(null, data);
 					}
 					else {
-						callback(new Error(`Sending of email failed: ${err}`));
+						callback(err);
 					}
 				}, 'POST');
 			});


### PR DESCRIPTION
Let's just pass the err we get to the callback