### PR TITLE
Added category limit

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -394,6 +394,7 @@ module.exports = (function() {
 			this.api.call({
 				action: 'query',
 				prop: 'categories',
+				cllimit: API_LIMIT,
 				titles: title
 			}, function(err, data) {
 				if (err) {


### PR DESCRIPTION
The default API category limit is 10 but 5000 for bots