### PR TITLE
Use the same proxy and jar for fetchUrl

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -258,16 +258,16 @@ module.exports = (function() {
 			this.queue.push(function(done) {
 				self.info("Fetching <%s> (as %s)...", url, encoding);
 
-        const options = {
-          url,
-          method: 'GET',
-          proxy: self.proxy || false,
-          jar: self.jar,
-          encoding: (encoding === 'binary') ? null : encoding,
-          headers: {
-            'User-Agent': self.userAgent
-          }
-        };
+				const options = {
+					url,
+					method: 'GET',
+					proxy: self.proxy || false,
+					jar: self.jar,
+					encoding: (encoding === 'binary') ? null : encoding,
+					headers: {
+					  'User-Agent': self.userAgent
+					}
+				};
 
 				request(options, function (error, response, body) {
 					if (!error && response.statusCode === 200) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -258,10 +258,18 @@ module.exports = (function() {
 			this.queue.push(function(done) {
 				self.info("Fetching <%s> (as %s)...", url, encoding);
 
-				request({
-					url,
-					encoding: (encoding === 'binary') ? null : encoding 
-				}, function (error, response, body) {
+        const options = {
+          url,
+          method: 'GET',
+          proxy: self.proxy || false,
+          jar: self.jar,
+          encoding: (encoding === 'binary') ? null : encoding,
+          headers: {
+            'User-Agent': self.userAgent
+          }
+        };
+
+				request(options, function (error, response, body) {
 					if (!error && response.statusCode === 200) {
 						self.info('<%s>: fetched %s kB', url, (body.length/1024).toFixed(2));
 						callback(null, body);


### PR DESCRIPTION
I have a use case where I needed to use `fetchUrl` to retrieve images from our wiki but the images are secured and only available to logged in users.

The previous `fetchUrl` wouldn't reuse the cookies provided by `login`.

I personally didn't need the proxy but I figure that if anyone needs to use nodemw's `fetchUrl` it's because it's preconfigured to do something unique. If they don't want the proxy and the jar they can use the normal `request` package.