### PR TITLE
remove explicit default port

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -160,7 +160,7 @@ module.exports = ( function () {
 		},
 		api = function ( options ) {
 			this.protocol = options.protocol || 'http';
-			this.port = options.port || ( this.protocol === 'https' ? 443 : 80 );
+			this.port = options.port;
 			this.server = options.server;
 			this.path = options.path;
 			this.proxy = options.proxy;


### PR DESCRIPTION
nodemw was telling the request module to explicitly specify port 80/443 as part of the URL even though it is not necessary and in fact breaks functionality for some mediawiki installations (e.g. [openwetware](https://openwetware.org)). 

The URLs would look like `https://myserver.org:443/wiki` before this fix and I was getting the following from openwetware:

```
<!DOCTYPE html>
<html>
  <head>
    <title>503 Backend fetch failed</title>
  </head>
  <body>
    <h1>Error 503 Backend fetch failed</h1>
    <p>Backend fetch failed</p>
    <h3>Guru Meditation:</h3>
    <p>XID: 11808784</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>
```