### PR TITLE
Minor exception handling for login

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,10 +154,10 @@ module.exports = ( function () {
 
 			const self = this,
 				logInCallback = function ( err, data ) {
-          if (data == null) {
-            self.error('Logging in failed: no data received');
-            callback(err || new Error(`Logging in failed: no data received`));
-          } else if ( !err && typeof data.lgusername !== 'undefined' ) {
+					if (data == null) {
+						self.error('Logging in failed: no data received');
+						callback(err || new Error(`Logging in failed: no data received`));
+					} else if ( !err && typeof data.lgusername !== 'undefined' ) {
 						self.log( `Logged in as ${data.lgusername}` );
 						callback( null, data );
 					} else if ( typeof data.reason === 'undefined' ) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,10 @@ module.exports = ( function () {
 
 			const self = this,
 				logInCallback = function ( err, data ) {
-					if ( !err && typeof data.lgusername !== 'undefined' ) {
+          if (data == null) {
+            self.error('Logging in failed: no data received');
+            callback(err || new Error(`Logging in failed: no data received`));
+          } else if ( !err && typeof data.lgusername !== 'undefined' ) {
 						self.log( `Logged in as ${data.lgusername}` );
 						callback( null, data );
 					} else if ( typeof data.reason === 'undefined' ) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,7 +154,7 @@ module.exports = ( function () {
 
 			const self = this,
 				logInCallback = function ( err, data ) {
-					if (data == null) {
+					if (data === null || typeof data === 'undefined') {
 						self.error('Logging in failed: no data received');
 						callback(err || new Error(`Logging in failed: no data received`));
 					} else if ( !err && typeof data.lgusername !== 'undefined' ) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -154,9 +154,9 @@ module.exports = ( function () {
 
 			const self = this,
 				logInCallback = function ( err, data ) {
-					if (data == null) {
-						self.error('Logging in failed: no data received');
-						callback(err || new Error(`Logging in failed: no data received`));
+					if ( data === null || typeof data === 'undefined' ) {
+						self.error( 'Logging in failed: no data received' );
+						callback( err || new Error( 'Logging in failed: no data received' ) );
 					} else if ( !err && typeof data.lgusername !== 'undefined' ) {
 						self.log( `Logged in as ${data.lgusername}` );
 						callback( null, data );


### PR DESCRIPTION
We were hitting a case during login where the data object was undefined, causing the subsequent `data.reason === 'undefined'` to fall over.

This change doesn't attempt to fix the root cause of undefined data, but to handle that case more gracefully.