### PR TITLE
build: Add Node 12, fix cache, discontinue Node 8

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,11 @@
 {
-    "extends": "wikimedia",
-    "env": {
-        "node": true,
-        "es6": true
-    },
+    "extends": [
+        "wikimedia",
+        "wikimedia/node",
+        "wikimedia/language/es2016"
+    ],
     "rules": {
+        "prefer-const": "off",
         "no-console": "off"
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 sudo: false
 node_js:
+  - 12
   - 10
-  - 8
-  - 6
 script: "npm test && npm run-script lint"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
-sudo: false
 node_js:
   - 12
   - 10
-script: "npm test && npm run-script lint"
-cache:
-  directories:
-    - node_modules
+cache: npm

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 nodemw
 ======
 
-[MediaWiki API](http://www.mediawiki.org/wiki/API:Main_page) client written in node.js
+[MediaWiki API](https://www.mediawiki.org/wiki/API:Main_page) client written in node.js
 
-[![NPM version](https://badge.fury.io/js/nodemw.png)](http://badge.fury.io/js/nodemw)
-[![Build Status](https://api.travis-ci.org/macbre/nodemw.svg?branch=devel)](http://travis-ci.org/macbre/nodemw)
+[![NPM version](https://badge.fury.io/js/nodemw.svg)](https://www.npmjs.com/package/nodemw)
+[![Build Status](https://api.travis-ci.org/macbre/nodemw.svg?branch=devel)](https://travis-ci.org/macbre/nodemw)
 
 [![Download stats](https://nodei.co/npm/nodemw.png?downloads=true&downloadRank=true)](https://nodei.co/npm/nodemw/)
 

--- a/examples/getToken.js
+++ b/examples/getToken.js
@@ -15,11 +15,15 @@ const Bot = require( '..' ),
 	} );
 
 wikia.getToken( 'Main_page', 'edit', function ( err, token ) {
-	if ( err ) { wikia.log( err ); }
+	if ( err ) {
+		wikia.log( err );
+	}
 	wikia.log( 'Wikia:', token );
 } );
 
 wikipedia.getToken( 'Main_page', 'edit', function ( err, token ) {
-	if ( err ) { wikipedia.log( err ); }
+	if ( err ) {
+		wikipedia.log( err );
+	}
 	wikipedia.log( 'Wikipedia:', token );
 } );

--- a/examples/meaninglessNamedImages.js
+++ b/examples/meaninglessNamedImages.js
@@ -104,7 +104,9 @@ client.logIn( function () {
 				} );
 				let i = 0;
 				imagesToDo.forEach( function ( item ) {
-					setTimeout( function () { rename( item ); }, 10000 * i );
+					setTimeout( function () {
+						rename( item );
+					}, 10000 * i );
 					i++;
 				} );
 				console.log( `do przerobienia: ${i}` );

--- a/examples/purge.js
+++ b/examples/purge.js
@@ -13,26 +13,34 @@ const Bot = require( '..' ),
 	} );
 
 client.purge( [ 'Pomnik_Bamberki', 'Ratusz' ], function ( err, data ) {
-	if ( err ) { client.log( err ); }
+	if ( err ) {
+		client.log( err );
+	}
 	console.log( data );
 } );
 
 // purge all articles in a given category (note a "Category:" prefix)
 client.purge( 'Category:Ratusz', function ( err, data ) {
-	if ( err ) { client.log( err ); }
+	if ( err ) {
+		client.log( err );
+	}
 	console.log( data );
 } );
 
 // purge all articles in a given category the old way (before MW 1.21)
 client.getPagesInCategory( 'Ratusz', function ( err, pages ) {
-	if ( err ) { return; }
+	if ( err ) {
+		return;
+	}
 
 	const pageIds = pages
 		.filter( ( page ) => page.ns === 0 )
 		.map( ( page ) => page.pageid );
 
 	client.purge( pageIds, function ( err, data ) {
-		if ( err ) { client.log( err ); }
+		if ( err ) {
+			client.log( err );
+		}
 		console.log( data );
 	} );
 } );

--- a/examples/specialLog2csv.js
+++ b/examples/specialLog2csv.js
@@ -49,7 +49,9 @@ async.whilst(
 		} );
 	},
 	function ( err ) {
-		if ( err ) { throw err; }
+		if ( err ) {
+			throw err;
+		}
 
 		client.log( 'Done' );
 	}

--- a/examples/wikidata.js
+++ b/examples/wikidata.js
@@ -67,7 +67,7 @@ class WikiData {
 	}
 }
 
-const data = new WikiData(); // eslint-disable-line one-var
+const data = new WikiData();
 
 data.getEntities(
 	[

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,291 +1,293 @@
 /**
  * Helper "class" for accessing MediaWiki API and handling cookie-based session
  */
-module.exports = ( function () {
-	'use strict';
+'use strict';
 
-	// introspect package.json to get module version
-	const VERSION = require( '../package' ).version,
-		// @see https://github.com/caolan/async
-		async = require( 'async' ),
-		// @see https://github.com/mikeal/request
-		request = require( 'request' ),
-		doRequest = function ( params, callback, method, done ) {
-			const self = this,
-				// store requested action - will be used when parsing a response
-				actionName = params.action,
-				// "request" options
-				options = {
-					method: method || 'GET',
-					proxy: this.proxy || false,
-					jar: this.jar,
-					headers: {
-						'User-Agent': this.userAgent
-					}
-				};
+// introspect package.json to get module version
+const VERSION = require( '../package' ).version;
 
-			// HTTP request parameters
-			params = params || {};
+// @see https://github.com/caolan/async
+const async = require( 'async' );
 
-			// force JSON format
-			params.format = 'json';
+// @see https://github.com/mikeal/request
+const request = require( 'request' );
 
-			// handle uploads
-			if ( method === 'UPLOAD' ) {
-				options.method = 'POST';
-
-				const CRLF = '\r\n',
-					postBody = [],
-					boundary = `nodemw${Math.random().toString().substr( 2 )}`;
-
-				// encode each field
-				Object.keys( params ).forEach( function ( fieldName ) {
-					const value = params[ fieldName ];
-
-					postBody.push( `--${boundary}` );
-					postBody.push( CRLF );
-
-					if ( typeof value === 'string' ) {
-					// properly encode UTF8 in binary-safe POST data
-						postBody.push( `Content-Disposition: form-data; name="${fieldName}"` );
-						postBody.push( CRLF );
-						postBody.push( CRLF );
-						postBody.push( new Buffer( value, 'utf8' ) );
-					} else {
-					// send attachment
-						postBody.push( `Content-Disposition: form-data; name="${fieldName}"; filename="foo"` );
-						postBody.push( CRLF );
-						postBody.push( CRLF );
-						postBody.push( value );
-					}
-
-					postBody.push( CRLF );
-				} );
-
-				postBody.push( `--${boundary}--` );
-
-				// encode post data
-				options.headers[ 'content-type' ] = `multipart/form-data; boundary=${boundary}`;
-				options.body = postBody;
-
-				params = {};
+function doRequest( params, callback, method, done ) {
+	const self = this,
+		// store requested action - will be used when parsing a response
+		actionName = params.action,
+		// "request" options
+		options = {
+			method: method || 'GET',
+			proxy: this.proxy || false,
+			jar: this.jar,
+			headers: {
+				'User-Agent': this.userAgent
 			}
-
-			// form an URL to API
-			options.url = this.formatUrl( {
-				protocol: this.protocol,
-				port: this.port,
-				hostname: this.server,
-				pathname: this.path + '/api.php',
-				query: ( options.method === 'GET' ) ? params : {}
-			} );
-
-			// POST all parameters (avoid "request string too long" errors)
-			if ( method === 'POST' ) {
-				options.form = params;
-			}
-
-			this.logger.debug( 'API action: %s', actionName );
-			this.logger.debug( '%s <%s>', options.method, options.url );
-			if ( options.form ) {
-				this.logger.debug( 'POST fields: %s', Object.keys( options.form ).join( ', ' ) );
-			}
-
-			request( options, function ( error, response, body ) {
-				response = response || {};
-
-				if ( error ) {
-					self.logger.error( 'Request to API failed: %s', error );
-					callback( new Error( `Request to API failed: ${error}` ) );
-					done();
-					return;
-				}
-
-				if ( response.statusCode !== 200 ) {
-					self.logger.error( 'Request to API failed: HTTP status code was %d for <%s>', response.statusCode || 'unknown', options.url );
-					self.logger.debug( 'Body: %s', body );
-
-					self.logger.data( new Error().stack );
-
-					callback( new Error( `Request to API failed: HTTP status code was ${response.statusCode}` ) );
-					done();
-					return;
-				}
-
-				// parse response
-				let data,
-					info,
-					next;
-
-				try {
-					data = JSON.parse( body );
-					info = data && data[ actionName ];
-
-					// acfrom=Zeppelin Games
-					next = data && data[ 'query-continue' ] && data[ 'query-continue' ][ params.list || params.prop ];
-
-					// handle the new continuing queries introduced in MW 1.21
-					// (and to be made default in MW 1.26)
-					// issue #64
-					// @see https://www.mediawiki.org/wiki/API:Query#Continuing_queries
-					if ( !next ) {
-					// cmcontinue=page|5820414e44205920424f534f4e53|12253446, continue=-||
-						next = data && data.continue;
-					}
-				} catch ( e ) {
-					self.logger.error( 'Error parsing JSON response: %s', body );
-					self.logger.data( body );
-
-					callback( new Error( 'Error parsing JSON response' ) );
-					done();
-					return;
-				}
-
-				// if (!callback) data.error = {info: 'foo'}; // debug
-
-				if ( data && !data.error ) {
-					if ( next ) {
-						self.logger.debug( 'There\'s more data' );
-						self.logger.debug( next );
-					}
-
-					callback( null, info, next, data );
-				} else if ( data.error ) {
-					self.logger.error( 'Error returned by API: %s', data.error.info );
-					self.logger.data( data.error );
-
-					callback( new Error( `Error returned by API: ${data.error.info}` ) );
-				}
-				done();
-			} );
-		},
-		api = function ( options ) {
-			this.protocol = options.protocol || 'http';
-			this.port = options.port;
-			this.server = options.server;
-			this.path = options.path;
-			this.proxy = options.proxy;
-			this.jar = request.jar(); // create new cookie jar for each instance
-
-			this.debug = options.debug;
-
-			// set up logging
-			const winston = require( 'winston' ),
-				// file logging
-				path = require( 'path' ),
-				fs = require( 'fs' ),
-				logDir = path.dirname( process.argv[ 1 ] ) + '/log/',
-				logFile = logDir + path.basename( process.argv[ 1 ], '.js' ) + '.log',
-				// how many tasks (i.e. requests) to run in parallel
-				concurrency = options.concurrency || 3;
-
-			this.logger = new ( winston.Logger )();
-
-			// console logging
-			if ( this.debug ) {
-				this.logger.add( winston.transports.Console, {
-					level: 'debug'
-				} );
-			}
-
-			this.logger.cli();
-
-			if ( fs.existsSync( logDir ) ) {
-				this.logger.add( winston.transports.File, {
-					colorize: true,
-					filename: logFile,
-					json: false,
-					level: this.debug ? 'debug' : 'info'
-				} );
-			}
-
-			// requests queue
-			// @see https://github.com/caolan/async#queue
-			this.queue = async.queue( function ( task, callback ) {
-			// process the task (and call the provided callback once it's completed)
-				task( callback );
-			}, concurrency );
-
-			// HTTP client
-			this.formatUrl = require( 'url' ).format;
-
-			this.userAgent = options.userAgent || ( `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})` );
-			this.version = VERSION;
-
-			// debug info
-			this.info( process.argv.join( ' ' ) );
-			this.info( this.userAgent );
-
-			let port = this.port ? `:${this.port}` : '';
-
-			this.info( `Using <${this.protocol}://${this.server}${port}${this.path}/api.php> as API entry point` );
-			this.info( '----' );
 		};
 
-	// public interface
-	api.prototype = {
-		log() {
-			this.logger.log.apply( this.logger, arguments );
-		},
+	// HTTP request parameters
+	params = params || {};
 
-		info() {
-			this.logger.info.apply( this.logger, arguments );
-		},
+	// force JSON format
+	params.format = 'json';
 
-		warn() {
-			this.logger.warn.apply( this.logger, arguments );
-		},
+	// handle uploads
+	if ( method === 'UPLOAD' ) {
+		options.method = 'POST';
 
-		error() {
-			this.logger.error.apply( this.logger, arguments );
-		},
+		const CRLF = '\r\n',
+			postBody = [],
+			boundary = `nodemw${Math.random().toString().substr( 2 )}`;
 
-		// adds request to the queue
-		call( params, callback, method ) {
-			this.queue.push( ( done ) => {
-				doRequest.apply( this, [ params, callback, method, done ] );
-			} );
-		},
+		// encode each field
+		Object.keys( params ).forEach( function ( fieldName ) {
+			const value = params[ fieldName ];
 
-		// fetch an external resource
-		fetchUrl( url, callback, encoding ) {
-			const self = this;
-			encoding = encoding || 'utf-8';
+			postBody.push( `--${boundary}` );
+			postBody.push( CRLF );
 
-			// add a request to the queue
-			this.queue.push( function ( done ) {
-				self.info( 'Fetching <%s> (as %s)...', url, encoding );
+			if ( typeof value === 'string' ) {
+			// properly encode UTF8 in binary-safe POST data
+				postBody.push( `Content-Disposition: form-data; name="${fieldName}"` );
+				postBody.push( CRLF );
+				postBody.push( CRLF );
+				postBody.push( Buffer.from( value, 'utf8' ) );
+			} else {
+			// send attachment
+				postBody.push( `Content-Disposition: form-data; name="${fieldName}"; filename="foo"` );
+				postBody.push( CRLF );
+				postBody.push( CRLF );
+				postBody.push( value );
+			}
 
-				const options = {
-					url,
-					method: 'GET',
-					proxy: self.proxy || false,
-					jar: self.jar,
-					encoding: ( encoding === 'binary' ) ? null : encoding,
-					headers: {
-						'User-Agent': self.userAgent
-					}
-				};
+			postBody.push( CRLF );
+		} );
 
-				request( options, function ( error, response, body ) {
-					if ( !error && response.statusCode === 200 ) {
-						self.info( '<%s>: fetched %s kB', url, ( body.length / 1024 ).toFixed( 2 ) );
-						callback( null, body );
-					} else {
-						if ( !error ) {
-							error = new Error( `HTTP status ${response.statusCode}` );
-						}
+		postBody.push( `--${boundary}--` );
 
-						self.error( `Failed to fetch <${url}>` );
-						self.error( error.message );
-						callback( error, body );
-					}
+		// encode post data
+		options.headers[ 'content-type' ] = `multipart/form-data; boundary=${boundary}`;
+		options.body = postBody;
 
-					done();
-				} );
-			} );
+		params = {};
+	}
+
+	// form an URL to API
+	options.url = this.formatUrl( {
+		protocol: this.protocol,
+		port: this.port,
+		hostname: this.server,
+		pathname: this.path + '/api.php',
+		query: ( options.method === 'GET' ) ? params : {}
+	} );
+
+	// POST all parameters (avoid "request string too long" errors)
+	if ( method === 'POST' ) {
+		options.form = params;
+	}
+
+	this.logger.debug( 'API action: %s', actionName );
+	this.logger.debug( '%s <%s>', options.method, options.url );
+	if ( options.form ) {
+		this.logger.debug( 'POST fields: %s', Object.keys( options.form ).join( ', ' ) );
+	}
+
+	request( options, function ( error, response, body ) {
+		response = response || {};
+
+		if ( error ) {
+			self.logger.error( 'Request to API failed: %s', error );
+			callback( new Error( `Request to API failed: ${error}` ) );
+			done();
+			return;
 		}
-	};
 
-	return api;
-}() );
+		if ( response.statusCode !== 200 ) {
+			self.logger.error( 'Request to API failed: HTTP status code was %d for <%s>', response.statusCode || 'unknown', options.url );
+			self.logger.debug( 'Body: %s', body );
+
+			self.logger.data( new Error().stack );
+
+			callback( new Error( `Request to API failed: HTTP status code was ${response.statusCode}` ) );
+			done();
+			return;
+		}
+
+		// parse response
+		let data,
+			info,
+			next;
+
+		try {
+			data = JSON.parse( body );
+			info = data && data[ actionName ];
+
+			// acfrom=Zeppelin Games
+			next = data && data[ 'query-continue' ] && data[ 'query-continue' ][ params.list || params.prop ];
+
+			// handle the new continuing queries introduced in MW 1.21
+			// (and to be made default in MW 1.26)
+			// issue #64
+			// @see https://www.mediawiki.org/wiki/API:Query#Continuing_queries
+			if ( !next ) {
+			// cmcontinue=page|5820414e44205920424f534f4e53|12253446, continue=-||
+				next = data && data.continue;
+			}
+		} catch ( e ) {
+			self.logger.error( 'Error parsing JSON response: %s', body );
+			self.logger.data( body );
+
+			callback( new Error( 'Error parsing JSON response' ) );
+			done();
+			return;
+		}
+
+		// if (!callback) data.error = {info: 'foo'}; // debug
+
+		if ( data && !data.error ) {
+			if ( next ) {
+				self.logger.debug( 'There\'s more data' );
+				self.logger.debug( next );
+			}
+
+			callback( null, info, next, data );
+		} else if ( data.error ) {
+			self.logger.error( 'Error returned by API: %s', data.error.info );
+			self.logger.data( data.error );
+
+			callback( new Error( `Error returned by API: ${data.error.info}` ) );
+		}
+		done();
+	} );
+}
+
+function Api( options ) {
+	this.protocol = options.protocol || 'http';
+	this.port = options.port;
+	this.server = options.server;
+	this.path = options.path;
+	this.proxy = options.proxy;
+	this.jar = request.jar(); // create new cookie jar for each instance
+
+	this.debug = options.debug;
+
+	// set up logging
+	const winston = require( 'winston' ),
+		// file logging
+		path = require( 'path' ),
+		fs = require( 'fs' ),
+		logDir = path.dirname( process.argv[ 1 ] ) + '/log/',
+		logFile = logDir + path.basename( process.argv[ 1 ], '.js' ) + '.log',
+		// how many tasks (i.e. requests) to run in parallel
+		concurrency = options.concurrency || 3;
+
+	this.logger = new ( winston.Logger )();
+
+	// console logging
+	if ( this.debug ) {
+		this.logger.add( winston.transports.Console, {
+			level: 'debug'
+		} );
+	}
+
+	this.logger.cli();
+
+	if ( fs.existsSync( logDir ) ) {
+		this.logger.add( winston.transports.File, {
+			colorize: true,
+			filename: logFile,
+			json: false,
+			level: this.debug ? 'debug' : 'info'
+		} );
+	}
+
+	// requests queue
+	// @see https://github.com/caolan/async#queue
+	this.queue = async.queue( function ( task, callback ) {
+	// process the task (and call the provided callback once it's completed)
+		task( callback );
+	}, concurrency );
+
+	// HTTP client
+	this.formatUrl = require( 'url' ).format;
+
+	this.userAgent = options.userAgent || ( `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})` );
+	this.version = VERSION;
+
+	// debug info
+	this.info( process.argv.join( ' ' ) );
+	this.info( this.userAgent );
+
+	let port = this.port ? `:${this.port}` : '';
+
+	this.info( `Using <${this.protocol}://${this.server}${port}${this.path}/api.php> as API entry point` );
+	this.info( '----' );
+}
+
+// public interface
+Api.prototype = {
+	log() {
+		this.logger.log.apply( this.logger, arguments );
+	},
+
+	info() {
+		this.logger.info.apply( this.logger, arguments );
+	},
+
+	warn() {
+		this.logger.warn.apply( this.logger, arguments );
+	},
+
+	error() {
+		this.logger.error.apply( this.logger, arguments );
+	},
+
+	// adds request to the queue
+	call( params, callback, method ) {
+		this.queue.push( ( done ) => {
+			doRequest.apply( this, [ params, callback, method, done ] );
+		} );
+	},
+
+	// fetch an external resource
+	fetchUrl( url, callback, encoding ) {
+		const self = this;
+		encoding = encoding || 'utf-8';
+
+		// add a request to the queue
+		this.queue.push( function ( done ) {
+			self.info( 'Fetching <%s> (as %s)...', url, encoding );
+
+			const options = {
+				url,
+				method: 'GET',
+				proxy: self.proxy || false,
+				jar: self.jar,
+				encoding: ( encoding === 'binary' ) ? null : encoding,
+				headers: {
+					'User-Agent': self.userAgent
+				}
+			};
+
+			request( options, function ( error, response, body ) {
+				if ( !error && response.statusCode === 200 ) {
+					self.info( '<%s>: fetched %s kB', url, ( body.length / 1024 ).toFixed( 2 ) );
+					callback( null, body );
+				} else {
+					if ( !error ) {
+						error = new Error( `HTTP status ${response.statusCode}` );
+					}
+
+					self.error( `Failed to fetch <${url}>` );
+					self.error( error.message );
+					callback( error, body );
+				}
+
+				done();
+			} );
+		} );
+	}
+};
+
+module.exports = Api;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -2,1230 +2,1234 @@
 /**
  * Defines bot API
  */
-module.exports = ( function () {
-	'use strict';
+'use strict';
 
-	const Api = require( './api' ),
-		_ = require( 'underscore' ),
-		async = require( 'async' ),
-		fs = require( 'fs' ),
-		querystring = require( 'querystring' ),
-		// the upper limit for bots (will be reduced by MW for users without a bot right)
-		API_LIMIT = 5000,
-		// get the object being the first key/value entry of a given object
-		getFirstItem = function ( obj ) {
-			const key = Object.keys( obj ).shift();
-			return obj[ key ];
-		},
-		// bot public API
-		bot = function ( params ) {
-			let env = process.env,
-				options;
+const Api = require( './api' ),
+	_ = require( 'underscore' ),
+	async = require( 'async' ),
+	fs = require( 'fs' ),
+	querystring = require( 'querystring' ),
+	// the upper limit for bots (will be reduced by MW for users without a bot right)
+	API_LIMIT = 5000;
 
-			// read configuration from the file
-			if ( typeof params === 'string' ) {
-				let configFile,
-					configParsed;
+// get the object being the first key/value entry of a given object
+function getFirstItem( obj ) {
+	const key = Object.keys( obj ).shift();
+	return obj[ key ];
+}
 
-				try {
-					configFile = fs.readFileSync( params, 'utf-8' );
-					configParsed = JSON.parse( configFile );
-				} catch ( e ) {
-					throw new Error( `Loading config failed: ${e.message}` );
-				}
+// bot public API
+function Bot( params ) {
+	let env = process.env,
+		options;
 
-				if ( typeof configParsed === 'object' ) {
-					options = configParsed;
-				}
-			} else if ( typeof params === 'object' ) { // configuration provided as an object
-				options = params;
-			}
+	// read configuration from the file
+	if ( typeof params === 'string' ) {
+		let configFile,
+			configParsed;
 
-			if ( !params ) {
-				throw new Error( 'No configuration was provided!' );
-			}
+		try {
+			configFile = fs.readFileSync( params, 'utf-8' );
+			configParsed = JSON.parse( configFile );
+		} catch ( e ) {
+			throw new Error( `Loading config failed: ${e.message}` );
+		}
 
-			this.protocol = options.protocol;
-			this.server = options.server;
+		if ( typeof configParsed === 'object' ) {
+			options = configParsed;
+		}
+	} else if ( typeof params === 'object' ) { // configuration provided as an object
+		options = params;
+	}
 
-			const protocol = options.protocol || 'http';
-			this.api = new Api( {
-				protocol,
-				port: options.port,
-				server: options.server,
-				path: options.path || '',
-				proxy: options.proxy,
-				userAgent: options.userAgent,
-				concurrency: options.concurrency,
-				debug: ( options.debug === true || env.DEBUG === '1' )
-			} );
+	if ( !params ) {
+		throw new Error( 'No configuration was provided!' );
+	}
 
-			this.version = this.api.version;
+	this.protocol = options.protocol;
+	this.server = options.server;
 
-			// store options
-			this.options = options;
+	const protocol = options.protocol || 'http';
+	this.api = new Api( {
+		protocol,
+		port: options.port,
+		server: options.server,
+		path: options.path || '',
+		proxy: options.proxy,
+		userAgent: options.userAgent,
+		concurrency: options.concurrency,
+		debug: ( options.debug === true || env.DEBUG === '1' )
+	} );
 
-			// in dry-run mode? (issue #48)
-			this.dryRun = ( options.dryRun === true || env.DRY_RUN === '1' );
+	this.version = this.api.version;
 
-			if ( this.dryRun ) {
-				this.log( 'Running in dry-run mode' );
-			}
+	// store options
+	this.options = options;
 
-			// bind provider-specific "namespaces"
-			this.wikia.call = this.wikia.call.bind( this );
-		};
+	// in dry-run mode? (issue #48)
+	this.dryRun = ( options.dryRun === true || env.DRY_RUN === '1' );
 
-	bot.prototype = {
-		log() {
-			this.api.info.apply( this.api, arguments );
-		},
+	if ( this.dryRun ) {
+		this.log( 'Running in dry-run mode' );
+	}
 
-		logData( obj ) {
-			this.api.logger.data( JSON.stringify( obj, undefined, 2 ) );
-		},
+	// bind provider-specific "namespaces"
+	this.wikia.call = this.wikia.call.bind( this );
+}
 
-		error() {
-			this.api.error.apply( this.api, arguments );
-		},
+Bot.prototype = {
+	log() {
+		this.api.info.apply( this.api, arguments );
+	},
 
-		getConfig( key, def ) {
-			return this.options[ key ] || def;
-		},
+	logData( obj ) {
+		this.api.logger.data( JSON.stringify( obj, undefined, 2 ) );
+	},
 
-		setConfig( key, val ) {
-			this.options[ key ] = val;
-		},
+	error() {
+		this.api.error.apply( this.api, arguments );
+	},
 
-		getRand() {
-			return Math.random().toString().split( '.' ).pop();
-		},
+	getConfig( key, def ) {
+		return this.options[ key ] || def;
+	},
 
-		getAll( params, key, callback ) {
-			let self = this,
-				res = [],
-				// @see https://www.mediawiki.org/wiki/API:Query#Continuing_queries
-				continueParams = {
-					'continue': ''
-				};
+	setConfig( key, val ) {
+		this.options[ key ] = val;
+	},
 
-			async.whilst(
-				() => true, // run as long as there's more data
-				function ( callback ) {
-					self.api.call( _.extend( params, continueParams ), function ( err, data, next ) {
-						if ( err ) {
-							callback( err );
-						} else {
-							// append batch data
-							const batchData = ( typeof key === 'function' ) ? key( data ) : data[ key ];
+	getRand() {
+		return Math.random().toString().split( '.' ).pop();
+	},
 
-							res = res.concat( batchData );
+	getAll( params, key, callback ) {
+		let self = this,
+			res = [],
+			// @see https://www.mediawiki.org/wiki/API:Query#Continuing_queries
+			continueParams = {
+				continue: ''
+			};
 
-							// more pages?
-							continueParams = next;
-							callback( next ? null : true );
-						}
-					} );
-				},
-				function ( err ) {
-					if ( err instanceof Error ) {
+		async.whilst(
+			() => true, // run as long as there's more data
+			function ( callback ) {
+				self.api.call( _.extend( params, continueParams ), function ( err, data, next ) {
+					if ( err ) {
 						callback( err );
 					} else {
-						callback( null, res );
+						// append batch data
+						const batchData = ( typeof key === 'function' ) ? key( data ) : data[ key ];
+
+						res = res.concat( batchData );
+
+						// more pages?
+						continueParams = next;
+						callback( next ? null : true );
 					}
-				}
-			);
-		},
-
-		logIn( username, password, callback /* or just callback */ ) {
-
-			// assign domain if applicable
-			var domain = this.options.domain || '';
-
-			// username and password params can be omitted
-			if ( typeof username !== 'string' ) {
-				callback = username;
-
-				// use data from config
-				username = this.options.username;
-				password = this.options.password;
-			}
-
-			this.log( 'Obtaining login token...' );
-
-			const self = this,
-				logInCallback = function ( err, data ) {
-					if ( data === null || typeof data === 'undefined' ) {
-						self.error( 'Logging in failed: no data received' );
-						callback( err || new Error( 'Logging in failed: no data received' ) );
-					} else if ( !err && typeof data.lgusername !== 'undefined' ) {
-						self.log( `Logged in as ${data.lgusername}` );
-						callback( null, data );
-					} else if ( typeof data.reason === 'undefined' ) {
-						self.error( 'Logging in failed' );
-						self.error( data.result );
-						callback( err || new Error( `Logging in failed: ${data.result}` ) );
-					} else {
-						self.error( 'Logging in failed' );
-						self.error( data.result );
-						self.error( data.reason );
-						callback( err || new Error( `Logging in failed: ${data.result} - ${data.reason}` ) );
-					}
-				};
-
-			// request a token
-			this.api.call( {
-				action: 'login',
-				lgname: username,
-				lgpassword: password,
-				lgdomain: domain
-			}, function ( err, data ) {
-				if ( err ) {
+				} );
+			},
+			function ( err ) {
+				if ( err instanceof Error ) {
 					callback( err );
-					return;
-				}
-
-				if ( data.result === 'NeedToken' ) {
-					const token = data.token;
-
-					self.log( `Got token ${token}` );
-
-					// log in using a token
-					self.api.call( {
-						action: 'login',
-						lgname: username,
-						lgpassword: password,
-						lgtoken: token,
-						lgdomain: domain
-					}, logInCallback, 'POST' );
 				} else {
-					logInCallback( err, data );
+					callback( null, res );
 				}
-			}, 'POST' );
-		},
+			}
+		);
+	},
 
-		getCategories( prefix, callback ) {
-			if ( typeof prefix === 'function' ) {
-				callback = prefix;
+	logIn( username, password, callback /* or just callback */ ) {
+
+		// assign domain if applicable
+		var domain = this.options.domain || '';
+
+		// username and password params can be omitted
+		if ( typeof username !== 'string' ) {
+			callback = username;
+
+			// use data from config
+			username = this.options.username;
+			password = this.options.password;
+		}
+
+		this.log( 'Obtaining login token...' );
+
+		const self = this,
+			logInCallback = function ( err, data ) {
+				if ( data === null || typeof data === 'undefined' ) {
+					self.error( 'Logging in failed: no data received' );
+					callback( err || new Error( 'Logging in failed: no data received' ) );
+				} else if ( !err && typeof data.lgusername !== 'undefined' ) {
+					self.log( `Logged in as ${data.lgusername}` );
+					callback( null, data );
+				} else if ( typeof data.reason === 'undefined' ) {
+					self.error( 'Logging in failed' );
+					self.error( data.result );
+					callback( err || new Error( `Logging in failed: ${data.result}` ) );
+				} else {
+					self.error( 'Logging in failed' );
+					self.error( data.result );
+					self.error( data.reason );
+					callback( err || new Error( `Logging in failed: ${data.result} - ${data.reason}` ) );
+				}
+			};
+
+		// request a token
+		this.api.call( {
+			action: 'login',
+			lgname: username,
+			lgpassword: password,
+			lgdomain: domain
+		}, function ( err, data ) {
+			if ( err ) {
+				callback( err );
+				return;
 			}
 
-			this.getAll(
-				{
-					action: 'query',
-					list: 'allcategories',
-					acprefix: prefix || '',
-					aclimit: API_LIMIT
-				},
-				( data )=>data.allcategories.map( ( cat ) => cat[ '*' ] ),
-				callback
-			);
-		},
+			if ( data.result === 'NeedToken' ) {
+				const token = data.token;
 
-		getUsers( data, callback ) {
-			if ( typeof data === 'function' ) {
-				callback = data;
+				self.log( `Got token ${token}` );
+
+				// log in using a token
+				self.api.call( {
+					action: 'login',
+					lgname: username,
+					lgpassword: password,
+					lgtoken: token,
+					lgdomain: domain
+				}, logInCallback, 'POST' );
+			} else {
+				logInCallback( err, data );
 			}
+		}, 'POST' );
+	},
 
-			data = data || {};
+	getCategories( prefix, callback ) {
+		if ( typeof prefix === 'function' ) {
+			callback = prefix;
+		}
 
-			this.api.call( {
+		this.getAll(
+			{
 				action: 'query',
-				list: 'allusers',
-				auprefix: data.prefix || '',
-				auwitheditsonly: data.witheditsonly || false,
-				aulimit: API_LIMIT
-			}, function ( err, data ) {
-				callback( err, data && data.allusers || [] );
-			} );
-		},
+				list: 'allcategories',
+				acprefix: prefix || '',
+				aclimit: API_LIMIT
+			},
+			( data )=>data.allcategories.map( ( cat ) => cat[ '*' ] ),
+			callback
+		);
+	},
 
-		getAllPages( callback ) {
-			this.log( 'Getting all pages...' );
-			this.getAll(
-				{
-					action: 'query',
-					list: 'allpages',
-					apfilterredir: 'nonredirects', // do not include redirects
-					aplimit: API_LIMIT
-				},
-				'allpages',
-				callback
-			);
-		},
+	getUsers( data, callback ) {
+		if ( typeof data === 'function' ) {
+			callback = data;
+		}
 
-		getPagesInCategory( category, callback ) {
-			category = `Category:${category}`;
-			this.log( `Getting pages from ${category}...` );
+		data = data || {};
 
-			this.getAll(
-				{
-					action: 'query',
-					list: 'categorymembers',
-					cmtitle: category,
-					cmlimit: API_LIMIT
-				},
-				'categorymembers',
-				callback
-			);
-		},
+		this.api.call( {
+			action: 'query',
+			list: 'allusers',
+			auprefix: data.prefix || '',
+			auwitheditsonly: data.witheditsonly || false,
+			aulimit: API_LIMIT
+		}, function ( err, data ) {
+			callback( err, data && data.allusers || [] );
+		} );
+	},
 
-		getPagesInNamespace( namespace, callback ) {
-			this.log( `Getting pages in namespace ${namespace}` );
-
-			this.getAll(
-				{
-					action: 'query',
-					list: 'allpages',
-					apnamespace: namespace,
-					apfilterredir: 'nonredirects', // do not include redirects
-					aplimit: API_LIMIT
-				},
-				'allpages',
-				callback
-			);
-		},
-
-		getPagesByPrefix( prefix, callback ) {
-			this.log( `Getting pages by ${prefix} prefix...` );
-
-			this.api.call( {
+	getAllPages( callback ) {
+		this.log( 'Getting all pages...' );
+		this.getAll(
+			{
 				action: 'query',
 				list: 'allpages',
-				apprefix: prefix,
+				apfilterredir: 'nonredirects', // do not include redirects
 				aplimit: API_LIMIT
-			}, function ( err, data ) {
-				callback( err, data && data.allpages || [] );
-			} );
-		},
+			},
+			'allpages',
+			callback
+		);
+	},
 
-		getPagesTranscluding( template, callback ) {
-			this.log( `Getting pages from ${template}...` );
+	getPagesInCategory( category, callback ) {
+		category = `Category:${category}`;
+		this.log( `Getting pages from ${category}...` );
 
-			this.getAll(
-				{
-					action: 'query',
-					prop: 'transcludedin',
-					titles: template
-				},
-				( data ) => getFirstItem( getFirstItem( data ) ).transcludedin,
-				callback
+		this.getAll(
+			{
+				action: 'query',
+				list: 'categorymembers',
+				cmtitle: category,
+				cmlimit: API_LIMIT
+			},
+			'categorymembers',
+			callback
+		);
+	},
+
+	getPagesInNamespace( namespace, callback ) {
+		this.log( `Getting pages in namespace ${namespace}` );
+
+		this.getAll(
+			{
+				action: 'query',
+				list: 'allpages',
+				apnamespace: namespace,
+				apfilterredir: 'nonredirects', // do not include redirects
+				aplimit: API_LIMIT
+			},
+			'allpages',
+			callback
+		);
+	},
+
+	getPagesByPrefix( prefix, callback ) {
+		this.log( `Getting pages by ${prefix} prefix...` );
+
+		this.api.call( {
+			action: 'query',
+			list: 'allpages',
+			apprefix: prefix,
+			aplimit: API_LIMIT
+		}, function ( err, data ) {
+			callback( err, data && data.allpages || [] );
+		} );
+	},
+
+	getPagesTranscluding( template, callback ) {
+		this.log( `Getting pages from ${template}...` );
+
+		this.getAll(
+			{
+				action: 'query',
+				prop: 'transcludedin',
+				titles: template
+			},
+			( data ) => getFirstItem( getFirstItem( data ) ).transcludedin,
+			callback
+		);
+	},
+
+	getArticle( title, redirect, callback ) {
+		let params = {
+			action: 'query',
+			prop: 'revisions',
+			rvprop: 'content',
+			rand: this.getRand()
+		};
+
+		if ( typeof redirect === 'function' ) {
+			callback = redirect;
+			redirect = undefined;
+		}
+
+		// @see https://www.mediawiki.org/wiki/API:Query#Resolving_redirects
+		if ( redirect === true ) {
+			params.redirects = '';
+		}
+
+		// both page ID or title can be provided
+		if ( typeof title === 'number' ) {
+			this.log( `Getting content of article #${title}...` );
+			params.pageids = title;
+		} else {
+			this.log( `Getting content of ${title}...` );
+			params.titles = title;
+		}
+
+		this.api.call( params, function ( err, data ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			const page = getFirstItem( data.pages ),
+				revision = page.revisions && page.revisions.shift(),
+				content = revision && revision[ '*' ],
+				redirectInfo = data.redirects && data.redirects.shift() || undefined;
+
+			callback( null, content, redirectInfo );
+		} );
+	},
+
+	getArticleRevisions( title, callback ) {
+		const params = {
+			action: 'query',
+			prop: 'revisions',
+			rvprop: [ 'ids', 'timestamp', 'size', 'flags', 'comment', 'user' ].join( '|' ),
+			rvdir: 'newer', // order by timestamp asc
+			rvlimit: API_LIMIT
+		};
+
+		// both page ID or title can be provided
+		if ( typeof title === 'number' ) {
+			this.log( `Getting revisions of article #${title}...` );
+			params.pageids = title;
+		} else {
+			this.log( `Getting revisions of ${title}...` );
+			params.titles = title;
+		}
+
+		this.getAll(
+			params,
+			function ( batch ) {
+				const page = getFirstItem( batch.pages );
+				return page.revisions;
+			},
+			callback
+		);
+	},
+
+	getArticleCategories( title, callback ) {
+		this.api.call( {
+			action: 'query',
+			prop: 'categories',
+			cllimit: API_LIMIT,
+			titles: title
+		}, function ( err, data ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			if ( data === null ) {
+				callback( new Error( `"${title}" page does not exist` ) );
+				return;
+			}
+
+			const page = getFirstItem( data.pages );
+
+			callback(
+				null,
+				( page.categories || [] ).map( ( cat ) =>
+					// { ns: 14, title: 'Kategoria:XX wiek' }
+					cat.title
+				)
 			);
-		},
+		} );
+	},
 
-		getArticle( title, redirect, callback ) {
-			let params = {
+	search( keyword, callback ) {
+		this.getAll(
+			{
 				action: 'query',
-				prop: 'revisions',
-				rvprop: 'content',
-				rand: this.getRand()
-			};
+				list: 'search',
+				srsearch: keyword,
+				srprop: 'timestamp',
+				srlimit: 5000
+			},
+			'search',
+			callback
+		);
+	},
 
-			if ( typeof redirect === 'function' ) {
-				callback = redirect;
-				redirect = undefined;
-			}
+	// get token required to perform a given action
+	getToken( title, action, callback ) {
+		this.log( `Getting ${action} token (for ${title})...` );
 
-			// @see https://www.mediawiki.org/wiki/API:Query#Resolving_redirects
-			if ( redirect === true ) {
-				params.redirects = '';
-			}
-
-			// both page ID or title can be provided
-			if ( typeof title === 'number' ) {
-				this.log( `Getting content of article #${title}...` );
-				params.pageids = title;
-			} else {
-				this.log( `Getting content of ${title}...` );
-				params.titles = title;
-			}
-
-			this.api.call( params, function ( err, data ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				const page = getFirstItem( data.pages ),
-					revision = page.revisions && page.revisions.shift(),
-					content = revision && revision[ '*' ],
-					redirectInfo = data.redirects && data.redirects.shift() || undefined;
-
-				callback( null, content, redirectInfo );
-			} );
-		},
-
-		getArticleRevisions( title, callback ) {
-			const params = {
-				action: 'query',
-				prop: 'revisions',
-				rvprop: [ 'ids', 'timestamp', 'size', 'flags', 'comment', 'user' ].join( '|' ),
-				rvdir: 'newer', // order by timestamp asc
-				rvlimit: API_LIMIT
-			};
-
-			// both page ID or title can be provided
-			if ( typeof title === 'number' ) {
-				this.log( `Getting revisions of article #${title}...` );
-				params.pageids = title;
-			} else {
-				this.log( `Getting revisions of ${title}...` );
-				params.titles = title;
-			}
-
-			this.getAll(
+		this.getMediaWikiVersion( ( ( err, version ) => {
+			let compare = require( 'node-version-compare' ),
 				params,
-				function ( batch ) {
-					const page = getFirstItem( batch.pages );
-					return page.revisions;
-				},
-				callback
-			);
-		},
+				useTokenApi = compare( version, '1.24.0' ) > -1;
 
-		getArticleCategories( title, callback ) {
-			this.api.call( {
-				action: 'query',
-				prop: 'categories',
-				cllimit: API_LIMIT,
-				titles: title
-			}, function ( err, data ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				if ( data === null ) {
-					callback( new Error( `"${title}" page does not exist` ) );
-					return;
-				}
-
-				const page = getFirstItem( data.pages );
-
-				callback(
-					null,
-					( page.categories || [] ).map( ( cat ) =>
-						// { ns: 14, title: 'Kategoria:XX wiek' }
-						cat.title
-					)
-				);
-			} );
-		},
-
-		search( keyword, callback ) {
-			this.getAll(
-				{
-					action: 'query',
-					list: 'search',
-					srsearch: keyword,
-					srprop: 'timestamp',
-					srlimit: 5000
-				},
-				'search',
-				callback
-			);
-		},
-
-		// get token required to perform a given action
-		getToken( title, action, callback ) {
-			this.log( `Getting ${action} token (for ${title})...` );
-
-			this.getMediaWikiVersion( ( ( err, version ) => {
-				let compare = require( 'node-version-compare' ),
-					params,
-					useTokenApi = compare( version, '1.24.0' ) > -1;
-
-				// @see https://www.mediawiki.org/wiki/API:Tokens (for MW 1.24+)
-				if ( useTokenApi ) {
-					params = {
-						action: 'query',
-						meta: 'tokens',
-						type: 'csrf'
-					};
-				} else {
-					params = {
-						action: 'query',
-						prop: 'info',
-						intoken: action,
-						titles: title
-					};
-				}
-
-				this.api.call( params, ( ( err, data, next, raw ) => {
-					let token;
-
-					if ( err ) {
-						callback( err );
-						return;
-					}
-
-					if ( useTokenApi ) {
-						token = data.tokens.csrftoken.toString(); // MW 1.24+
-					} else {
-						token = getFirstItem( data.pages )[ action + 'token' ]; // older MW version
-					}
-
-					if ( !token ) {
-						const msg = raw.warnings.info[ '*' ];
-						this.log( `getToken: ${msg}` );
-						err = new Error( `Can't get "${action}" token for "${title}" page - ${msg}` );
-						token = undefined;
-					}
-
-					callback( err, token );
-				} ) );
-			} ) );
-		},
-
-		// this should only be used internally (see #84)
-		doEdit( type, title, summary, params, callback ) {
-			const self = this;
-
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
-				return;
-			}
-
-			// @see http://www.mediawiki.org/wiki/API:Edit
-			this.getToken( title, 'edit', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				self.log( `Editing '${title}' with a summary '${summary}' (${type})...` );
-
-				const editParams = _.extend( {
-					action: 'edit',
-					bot: '',
-					title,
-					summary,
-					token
-				}, params );
-
-				self.api.call( editParams, function ( err, data ) {
-					if ( !err && data.result && data.result === 'Success' ) {
-						self.log( 'Rev #%d created for \'%s\'', data.newrevid, data.title );
-						callback( null, data );
-					} else {
-						callback( err || data );
-					}
-				}, 'POST' );
-			} );
-		},
-
-		edit( title, content, summary, minor, callback ) {
-			let params = {
-				text: content
-			};
-
-			if ( typeof minor === 'function' ) {
-				callback = minor;
-				minor = undefined;
-			}
-
-			if ( minor ) { params.minor = ''; } else { params.notminor = ''; }
-
-			this.doEdit( 'edit', title, summary, params, callback );
-		},
-
-		append( title, content, summary, callback ) {
-			let params = {
-				appendtext: content
-			};
-
-			this.doEdit( 'append', title, summary, params, callback );
-		},
-
-		prepend( title, content, summary, callback ) {
-			let params = {
-				prependtext: content
-			};
-
-			this.doEdit( 'prepend', title, summary, params, callback );
-		},
-
-		addFlowTopic( title, subject, content, callback ) {
-			const self = this;
-
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
-				return;
-			}
-
-			// @see http://www.mediawiki.org/wiki/API:Flow
-			this.getToken( title, 'flow', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				self.log( `Adding a topic to page '${title}' with subject '${subject}'...` );
-
-				const params = {
-					action: 'flow',
-					submodule: 'new-topic',
-					page: title,
-					nttopic: subject,
-					ntcontent: content,
-					ntformat: 'wikitext',
-					bot: '',
-					token: token
-				};
-
-				self.api.call( params, function ( err, data ) {
-					if ( !err && data[ 'new-topic' ] && data[ 'new-topic' ].status && data[ 'new-topic' ].status === 'ok' ) {
-						self.log( 'Workflow \'%s\' created on \'%s\'', data[ 'new-topic' ].workflow, title );
-						callback( null, data );
-					} else {
-						callback( err );
-					}
-				}, 'POST' );
-			} );
-		},
-
-		'delete'( title, reason, callback ) {
-			const self = this;
-
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
-				return;
-			}
-
-			// @see http://www.mediawiki.org/wiki/API:Delete
-			this.getToken( title, 'delete', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				self.log( 'Deleting \'%s\' because \'%s\'...', title, reason );
-
-				self.api.call( {
-					action: 'delete',
-					title,
-					reason,
-					token
-				}, function ( err, data ) {
-					if ( !err && data.title && data.reason ) {
-						callback( null, data );
-					} else {
-						callback( err );
-					}
-				}, 'POST' );
-			} );
-		},
-
-		purge( titles, callback ) {
-			// @see https://www.mediawiki.org/wiki/API:Purge
-			const self = this,
+			// @see https://www.mediawiki.org/wiki/API:Tokens (for MW 1.24+)
+			if ( useTokenApi ) {
 				params = {
-					action: 'purge'
+					action: 'query',
+					meta: 'tokens',
+					type: 'csrf'
 				};
-
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
-				return;
-			}
-
-			if ( typeof titles === 'string' && titles.indexOf( 'Category:' ) === 0 ) {
-				// @see https://docs.moodle.org/archive/pl/api.php?action=help&modules=purge
-				// @see https://docs.moodle.org/archive/pl/api.php?action=help&modules=query%2Bcategorymembers
-				// since MW 1.21 - @see https://github.com/wikimedia/mediawiki/commit/62216932c197f1c248ca2d95bc230f87a79ccd71
-				this.log( 'Purging all articles in category \'%s\'...', titles );
-				params.generator = 'categorymembers';
-				params.gcmtitle = titles;
 			} else {
-				// cast a single item to an array
-				titles = Array.isArray( titles ) ? titles : [ titles ];
-
-				// both page IDs or titles can be provided
-				if ( typeof titles[ 0 ] === 'number' ) {
-					this.log( 'Purging the list of article IDs: #%s...', titles.join( ', #' ) );
-					params.pageids = titles.join( '|' );
-				} else {
-					this.log( 'Purging the list of articles: \'%s\'...', titles.join( '\', \'' ) );
-					params.titles = titles.join( '|' );
-				}
+				params = {
+					action: 'query',
+					prop: 'info',
+					intoken: action,
+					titles: title
+				};
 			}
 
-			this.api.call(
-				params,
-				function ( err, data ) {
-					if ( !err ) {
-						data.forEach( function ( page ) {
-							if ( typeof page.purged !== 'undefined' ) {
-								self.log( 'Purged "%s"', page.title );
-							}
-						} );
-					}
+			this.api.call( params, ( ( err, data, next, raw ) => {
+				let token;
 
-					callback( err, data );
-				},
-				'POST'
-			);
-		},
-
-		sendEmail( username, subject, text, callback ) {
-			const self = this;
-
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
-				return;
-			}
-
-			// @see http://www.mediawiki.org/wiki/API:Email
-			this.getToken( `User:${username}`, 'email', function ( err, token ) {
 				if ( err ) {
 					callback( err );
 					return;
 				}
 
-				self.log( 'Sending an email to \'%s\' with subject \'%s\'...', username, subject );
-
-				self.api.call( {
-					action: 'emailuser',
-					target: username,
-					subject,
-					text,
-					ccme: '',
-					token
-				}, function ( err, data ) {
-					if ( !err && data.result && data.result === 'Success' ) {
-						self.log( 'Email sent' );
-						callback( null, data );
-					} else {
-						callback( err );
-					}
-				}, 'POST' );
-			} );
-		},
-
-		getUserContribs( options, callback ) {
-			options = options || {};
-
-			this.api.call( {
-				action: 'query',
-				list: 'usercontribs',
-				ucuser: options.user,
-				ucstart: options.start,
-				uclimit: API_LIMIT,
-				ucnamespace: options.namespace || ''
-			}, function ( err, data, next ) {
-				callback( err, data && data.usercontribs || [], next && next.ucstart || false );
-			} );
-		},
-
-		whoami( callback ) {
-			// @see http://www.mediawiki.org/wiki/API:Meta#userinfo_.2F_ui
-			const props = [
-				'groups',
-				'rights',
-				'ratelimits',
-				'editcount',
-				'realname',
-				'email'
-			];
-
-			this.api.call( {
-				action: 'query',
-				meta: 'userinfo',
-				uiprop: props.join( '|' )
-			}, function ( err, data ) {
-				if ( !err && data && data.userinfo ) {
-					callback( null, data.userinfo );
+				if ( useTokenApi ) {
+					token = data.tokens.csrftoken.toString(); // MW 1.24+
 				} else {
-					callback( err );
+					token = getFirstItem( data.pages )[ action + 'token' ]; // older MW version
 				}
-			} );
-		},
 
-		whois( username, callback ) {
-			this.whoare( [ username ], function ( err, usersinfo ) {
-				callback( err, usersinfo && usersinfo[ 0 ] );
-			} );
-		},
-
-		whoare( usernames, callback ) {
-			// @see https://www.mediawiki.org/wiki/API:Users
-			const props = [
-				'blockinfo',
-				'groups',
-				'implicitgroups',
-				'rights',
-				'editcount',
-				'registration',
-				'emailable',
-				'gender'
-			];
-
-			this.api.call( {
-				action: 'query',
-				list: 'users',
-				ususers: usernames.join( '|' ),
-				usprop: props.join( '|' )
-			}, function ( err, data ) {
-				if ( !err && data && data.users ) {
-					callback( null, data.users );
-				} else {
-					callback( err );
+				if ( !token ) {
+					const msg = raw.warnings.info[ '*' ];
+					this.log( `getToken: ${msg}` );
+					err = new Error( `Can't get "${action}" token for "${title}" page - ${msg}` );
+					token = undefined;
 				}
-			} );
-		},
 
-		createAccount( username, password, callback ) {
-			// @see https://www.mediawiki.org/wiki/API:Account_creation
-			const self = this;
-			this.log( `creating account ${username}` );
-			this.api.call( {
-				action: 'query',
-				meta: 'tokens',
-				type: 'createaccount'
-			}, function ( err, data ) {
-				self.api.call( {
-					action: 'createaccount',
-					createreturnurl: `${self.api.protocol}://${self.api.server}:${self.api.port}/`,
-					createtoken: data.tokens.createaccounttoken,
-					username: username,
-					password: password,
-					retype: password
-				}, function ( err, data ) {
-					if ( err ) {
-						callback( err );
-						return;
-					}
-					callback( data );
-				}, 'POST' );
-			} );
-		},
+				callback( err, token );
+			} ) );
+		} ) );
+	},
 
-		move( from, to, summary, callback ) {
-			const self = this;
+	// this should only be used internally (see #84)
+	doEdit( type, title, summary, params, callback ) {
+		const self = this;
 
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
+
+		// @see http://www.mediawiki.org/wiki/API:Edit
+		this.getToken( title, 'edit', function ( err, token ) {
+			if ( err ) {
+				callback( err );
 				return;
 			}
 
-			// @see http://www.mediawiki.org/wiki/API:Move
-			this.getToken( from, 'move', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
+			self.log( `Editing '${title}' with a summary '${summary}' (${type})...` );
+
+			const editParams = _.extend( {
+				action: 'edit',
+				bot: '',
+				title,
+				summary,
+				token
+			}, params );
+
+			self.api.call( editParams, function ( err, data ) {
+				if ( !err && data.result && data.result === 'Success' ) {
+					self.log( 'Rev #%d created for \'%s\'', data.newrevid, data.title );
+					callback( null, data );
+				} else {
+					callback( err || data );
 				}
+			}, 'POST' );
+		} );
+	},
 
-				self.log( 'Moving \'%s\' to \'%s\' because \'%s\'...', from, to, summary );
+	edit( title, content, summary, minor, callback ) {
+		let params = {
+			text: content
+		};
 
-				self.api.call( {
-					action: 'move',
-					from,
-					to,
-					bot: '',
-					reason: summary,
-					token
-				}, function ( err, data ) {
-					if ( !err && data.from && data.to && data.reason ) {
-						callback( null, data );
-					} else {
-						callback( err );
-					}
-				}, 'POST' );
-			} );
-		},
+		if ( typeof minor === 'function' ) {
+			callback = minor;
+			minor = undefined;
+		}
 
-		getImages( start, callback ) {
-			this.api.call( {
-				action: 'query',
-				list: 'allimages',
-				aifrom: start,
-				ailimit: API_LIMIT
-			}, function ( err, data, next ) {
-				callback( err, ( ( data && data.allimages ) || [] ), ( ( next && next.aifrom ) || false ) );
-			} );
-		},
+		if ( minor ) {
+			params.minor = '';
+		} else {
+			params.notminor = '';
+		}
 
-		getImagesFromArticle( title, callback ) {
-			this.api.call( {
-				action: 'query',
-				prop: 'images',
-				titles: title
+		this.doEdit( 'edit', title, summary, params, callback );
+	},
+
+	append( title, content, summary, callback ) {
+		let params = {
+			appendtext: content
+		};
+
+		this.doEdit( 'append', title, summary, params, callback );
+	},
+
+	prepend( title, content, summary, callback ) {
+		let params = {
+			prependtext: content
+		};
+
+		this.doEdit( 'prepend', title, summary, params, callback );
+	},
+
+	addFlowTopic( title, subject, content, callback ) {
+		const self = this;
+
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
+
+		// @see http://www.mediawiki.org/wiki/API:Flow
+		this.getToken( title, 'flow', function ( err, token ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			self.log( `Adding a topic to page '${title}' with subject '${subject}'...` );
+
+			const params = {
+				action: 'flow',
+				submodule: 'new-topic',
+				page: title,
+				nttopic: subject,
+				ntcontent: content,
+				ntformat: 'wikitext',
+				bot: '',
+				token: token
+			};
+
+			self.api.call( params, function ( err, data ) {
+				if ( !err && data[ 'new-topic' ] && data[ 'new-topic' ].status && data[ 'new-topic' ].status === 'ok' ) {
+					self.log( 'Workflow \'%s\' created on \'%s\'', data[ 'new-topic' ].workflow, title );
+					callback( null, data );
+				} else {
+					callback( err );
+				}
+			}, 'POST' );
+		} );
+	},
+
+	'delete'( title, reason, callback ) {
+		const self = this;
+
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
+
+		// @see http://www.mediawiki.org/wiki/API:Delete
+		this.getToken( title, 'delete', function ( err, token ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			self.log( 'Deleting \'%s\' because \'%s\'...', title, reason );
+
+			self.api.call( {
+				action: 'delete',
+				title,
+				reason,
+				token
 			}, function ( err, data ) {
-				const page = getFirstItem( data && data.pages || [] );
-				callback( err, ( page && page.images ) || [] );
-			} );
-		},
+				if ( !err && data.title && data.reason ) {
+					callback( null, data );
+				} else {
+					callback( err );
+				}
+			}, 'POST' );
+		} );
+	},
 
-		getImageUsage( filename, callback ) {
-			this.api.call( {
-				action: 'query',
-				list: 'imageusage',
-				iutitle: filename,
-				iulimit: API_LIMIT
-			}, function ( err, data ) {
-				callback( err, ( data && data.imageusage ) || [] );
-			} );
-		},
+	purge( titles, callback ) {
+		// @see https://www.mediawiki.org/wiki/API:Purge
+		const self = this,
+			params = {
+				action: 'purge'
+			};
 
-		getImageInfo( filename, callback ) {
-			const props = [
-				'timestamp',
-				'user',
-				'metadata',
-				'size',
-				'url'
-			];
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
 
-			this.api.call( {
-				action: 'query',
-				titles: filename,
-				prop: 'imageinfo',
-				iiprop: props.join( '|' )
-			}, function ( err, data ) {
-				const image = getFirstItem( data && data.pages || [] ),
-					imageinfo = image && image.imageinfo && image.imageinfo[ 0 ];
+		if ( typeof titles === 'string' && titles.indexOf( 'Category:' ) === 0 ) {
+			// @see https://docs.moodle.org/archive/pl/api.php?action=help&modules=purge
+			// @see https://docs.moodle.org/archive/pl/api.php?action=help&modules=query%2Bcategorymembers
+			// since MW 1.21 - @see https://github.com/wikimedia/mediawiki/commit/62216932c197f1c248ca2d95bc230f87a79ccd71
+			this.log( 'Purging all articles in category \'%s\'...', titles );
+			params.generator = 'categorymembers';
+			params.gcmtitle = titles;
+		} else {
+			// cast a single item to an array
+			titles = Array.isArray( titles ) ? titles : [ titles ];
 
-				// process EXIF metadata into key / value structure
-				if ( !err && imageinfo && imageinfo.metadata ) {
-					imageinfo.exif = {};
+			// both page IDs or titles can be provided
+			if ( typeof titles[ 0 ] === 'number' ) {
+				this.log( 'Purging the list of article IDs: #%s...', titles.join( ', #' ) );
+				params.pageids = titles.join( '|' );
+			} else {
+				this.log( 'Purging the list of articles: \'%s\'...', titles.join( '\', \'' ) );
+				params.titles = titles.join( '|' );
+			}
+		}
 
-					imageinfo.metadata.forEach( function ( entry ) {
-						imageinfo.exif[ entry.name ] = entry.value;
+		this.api.call(
+			params,
+			function ( err, data ) {
+				if ( !err ) {
+					data.forEach( function ( page ) {
+						if ( typeof page.purged !== 'undefined' ) {
+							self.log( 'Purged "%s"', page.title );
+						}
 					} );
 				}
 
-				callback( err, imageinfo );
-			} );
-		},
+				callback( err, data );
+			},
+			'POST'
+		);
+	},
 
-		getLog( type, start, callback ) {
-			let params = {
-				action: 'query',
-				list: 'logevents',
-				lestart: start,
-				lelimit: API_LIMIT
+	sendEmail( username, subject, text, callback ) {
+		const self = this;
+
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
+
+		// @see http://www.mediawiki.org/wiki/API:Email
+		this.getToken( `User:${username}`, 'email', function ( err, token ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			self.log( 'Sending an email to \'%s\' with subject \'%s\'...', username, subject );
+
+			self.api.call( {
+				action: 'emailuser',
+				target: username,
+				subject,
+				text,
+				ccme: '',
+				token
+			}, function ( err, data ) {
+				if ( !err && data.result && data.result === 'Success' ) {
+					self.log( 'Email sent' );
+					callback( null, data );
+				} else {
+					callback( err );
+				}
+			}, 'POST' );
+		} );
+	},
+
+	getUserContribs( options, callback ) {
+		options = options || {};
+
+		this.api.call( {
+			action: 'query',
+			list: 'usercontribs',
+			ucuser: options.user,
+			ucstart: options.start,
+			uclimit: API_LIMIT,
+			ucnamespace: options.namespace || ''
+		}, function ( err, data, next ) {
+			callback( err, data && data.usercontribs || [], next && next.ucstart || false );
+		} );
+	},
+
+	whoami( callback ) {
+		// @see http://www.mediawiki.org/wiki/API:Meta#userinfo_.2F_ui
+		const props = [
+			'groups',
+			'rights',
+			'ratelimits',
+			'editcount',
+			'realname',
+			'email'
+		];
+
+		this.api.call( {
+			action: 'query',
+			meta: 'userinfo',
+			uiprop: props.join( '|' )
+		}, function ( err, data ) {
+			if ( !err && data && data.userinfo ) {
+				callback( null, data.userinfo );
+			} else {
+				callback( err );
+			}
+		} );
+	},
+
+	whois( username, callback ) {
+		this.whoare( [ username ], function ( err, usersinfo ) {
+			callback( err, usersinfo && usersinfo[ 0 ] );
+		} );
+	},
+
+	whoare( usernames, callback ) {
+		// @see https://www.mediawiki.org/wiki/API:Users
+		const props = [
+			'blockinfo',
+			'groups',
+			'implicitgroups',
+			'rights',
+			'editcount',
+			'registration',
+			'emailable',
+			'gender'
+		];
+
+		this.api.call( {
+			action: 'query',
+			list: 'users',
+			ususers: usernames.join( '|' ),
+			usprop: props.join( '|' )
+		}, function ( err, data ) {
+			if ( !err && data && data.users ) {
+				callback( null, data.users );
+			} else {
+				callback( err );
+			}
+		} );
+	},
+
+	createAccount( username, password, callback ) {
+		// @see https://www.mediawiki.org/wiki/API:Account_creation
+		const self = this;
+		this.log( `creating account ${username}` );
+		this.api.call( {
+			action: 'query',
+			meta: 'tokens',
+			type: 'createaccount'
+		}, function ( err, data ) {
+			self.api.call( {
+				action: 'createaccount',
+				createreturnurl: `${self.api.protocol}://${self.api.server}:${self.api.port}/`,
+				createtoken: data.tokens.createaccounttoken,
+				username: username,
+				password: password,
+				retype: password
+			}, function ( err, data ) {
+				if ( err ) {
+					callback( err );
+					return;
+				}
+				callback( data );
+			}, 'POST' );
+		} );
+	},
+
+	move( from, to, summary, callback ) {
+		const self = this;
+
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
+
+		// @see http://www.mediawiki.org/wiki/API:Move
+		this.getToken( from, 'move', function ( err, token ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			self.log( 'Moving \'%s\' to \'%s\' because \'%s\'...', from, to, summary );
+
+			self.api.call( {
+				action: 'move',
+				from,
+				to,
+				bot: '',
+				reason: summary,
+				token
+			}, function ( err, data ) {
+				if ( !err && data.from && data.to && data.reason ) {
+					callback( null, data );
+				} else {
+					callback( err );
+				}
+			}, 'POST' );
+		} );
+	},
+
+	getImages( start, callback ) {
+		this.api.call( {
+			action: 'query',
+			list: 'allimages',
+			aifrom: start,
+			ailimit: API_LIMIT
+		}, function ( err, data, next ) {
+			callback( err, ( ( data && data.allimages ) || [] ), ( ( next && next.aifrom ) || false ) );
+		} );
+	},
+
+	getImagesFromArticle( title, callback ) {
+		this.api.call( {
+			action: 'query',
+			prop: 'images',
+			titles: title
+		}, function ( err, data ) {
+			const page = getFirstItem( data && data.pages || [] );
+			callback( err, ( page && page.images ) || [] );
+		} );
+	},
+
+	getImageUsage( filename, callback ) {
+		this.api.call( {
+			action: 'query',
+			list: 'imageusage',
+			iutitle: filename,
+			iulimit: API_LIMIT
+		}, function ( err, data ) {
+			callback( err, ( data && data.imageusage ) || [] );
+		} );
+	},
+
+	getImageInfo( filename, callback ) {
+		const props = [
+			'timestamp',
+			'user',
+			'metadata',
+			'size',
+			'url'
+		];
+
+		this.api.call( {
+			action: 'query',
+			titles: filename,
+			prop: 'imageinfo',
+			iiprop: props.join( '|' )
+		}, function ( err, data ) {
+			const image = getFirstItem( data && data.pages || [] ),
+				imageinfo = image && image.imageinfo && image.imageinfo[ 0 ];
+
+			// process EXIF metadata into key / value structure
+			if ( !err && imageinfo && imageinfo.metadata ) {
+				imageinfo.exif = {};
+
+				imageinfo.metadata.forEach( function ( entry ) {
+					imageinfo.exif[ entry.name ] = entry.value;
+				} );
+			}
+
+			callback( err, imageinfo );
+		} );
+	},
+
+	getLog( type, start, callback ) {
+		let params = {
+			action: 'query',
+			list: 'logevents',
+			lestart: start,
+			lelimit: API_LIMIT
+		};
+
+		if ( type.indexOf( '/' ) > 0 ) {
+			// Filter log entries to only this type.
+			params.leaction = type;
+		} else {
+			// Filter log actions to only this action. Overrides letype. In the list of possible values,
+			// values with the asterisk wildcard such as action/* can have different strings after the slash (/).
+			params.letype = type;
+		}
+
+		this.api.call( params, function ( err, data, next ) {
+			if ( next && next.lecontinue ) {
+				// 20150101124329|22700494
+				next = next.lecontinue.split( '|' ).shift();
+			}
+
+			callback( err, ( ( data && data.logevents ) || [] ), next );
+		} );
+	},
+
+	expandTemplates( text, title, callback ) {
+		this.api.call( {
+			action: 'expandtemplates',
+			text,
+			title,
+			generatexml: 1
+		}, function ( err, data, next, raw ) {
+			const xml = getFirstItem( raw.parsetree );
+			callback( err, xml );
+		}, 'POST' );
+	},
+
+	parse( text, title, callback ) {
+		this.api.call( {
+			action: 'parse',
+			text,
+			title,
+			contentmodel: 'wikitext',
+			generatexml: 1
+		}, function ( err, data, next, raw ) {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+			const xml = getFirstItem( raw.parse.text ),
+				images = raw.parse.images;
+			callback( err, xml, images );
+		}, 'POST' );
+	},
+
+	getRecentChanges( start, callback ) {
+		const props = [
+			'title',
+			'timestamp',
+			'comments',
+			'user',
+			'flags',
+			'sizes'
+		];
+
+		this.api.call( {
+			action: 'query',
+			list: 'recentchanges',
+			rcprop: props.join( '|' ),
+			rcstart: start || '',
+			rclimit: API_LIMIT
+		}, function ( err, data, next ) {
+			callback( err, ( ( data && data.recentchanges ) || [] ), ( ( next && next.rcstart ) || false ) );
+		} );
+	},
+
+	getSiteInfo( props, callback ) {
+		// @see http://www.mediawiki.org/wiki/API:Siteinfo
+		if ( typeof props === 'string' ) {
+			props = [ props ];
+		}
+
+		this.api.call( {
+			action: 'query',
+			meta: 'siteinfo',
+			siprop: props.join( '|' )
+		}, function ( err, data ) {
+			callback( err, data );
+		} );
+	},
+
+	getSiteStats( callback ) {
+		const prop = 'statistics';
+
+		this.getSiteInfo( prop, function ( err, info ) {
+			callback( err, info && info[ prop ] );
+		} );
+	},
+
+	getMediaWikiVersion( callback ) {
+		// cache it for each instance of the client
+		// we will call it multiple times for features detection
+		if ( typeof this._mwVersion !== 'undefined' ) { // eslint-disable-line no-underscore-dangle
+			callback( null, this._mwVersion ); // eslint-disable-line no-underscore-dangle
+			return;
+		}
+
+		this.getSiteInfo( [ 'general' ], ( ( err, info ) => {
+			let version;
+
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			version = info && info.general && info.general.generator; // e.g. "MediaWiki 1.27.0-wmf.19"
+			version = version.match( /[\d.]+/ )[ 0 ]; // 1.27.0
+
+			this.log( 'Detected MediaWiki v%s', version );
+
+			// cache it
+			this._mwVersion = version; // eslint-disable-line no-underscore-dangle
+			callback( null, this._mwVersion ); // eslint-disable-line no-underscore-dangle
+		} ) );
+	},
+
+	getQueryPage( queryPage, callback ) {
+		// @see http://www.mediawiki.org/wiki/API:Querypage
+		this.api.call( {
+			action: 'query',
+			list: 'querypage',
+			qppage: queryPage,
+			qplimit: API_LIMIT
+		}, ( err, data ) => {
+			if ( !err && data && data.querypage ) {
+				this.log( '%s data was generated %s', queryPage, data.querypage.cachedtimestamp );
+				callback( null, data.querypage.results || [] );
+			} else {
+				callback( err, [] );
+			}
+		} );
+	},
+
+	upload( filename, content, extraParams, callback ) {
+		let self = this,
+			params = {
+				action: 'upload',
+				ignorewarnings: '',
+				filename,
+				file: ( typeof content === 'string' ) ? Buffer.from( content, 'binary' ) : content,
+				text: ''
 			};
 
-			if ( type.indexOf( '/' ) > 0 ) {
-				// Filter log entries to only this type.
-				params.leaction = type;
-			} else {
-				// Filter log actions to only this action. Overrides letype. In the list of possible values,
-				// values with the asterisk wildcard such as action/* can have different strings after the slash (/).
-				params.letype = type;
-			}
+		if ( this.dryRun ) {
+			callback( new Error( 'In dry-run mode' ) );
+			return;
+		}
 
-			this.api.call( params, function ( err, data, next ) {
-				if ( next && next.lecontinue ) {
-					// 20150101124329|22700494
-					next = next.lecontinue.split( '|' ).shift();
-				}
+		if ( typeof extraParams === 'object' ) {
+			params = _.extend( params, extraParams );
+		} else { // it's summary (comment)
+			params.comment = extraParams;
+		}
 
-				callback( err, ( ( data && data.logevents ) || [] ), next );
-			} );
-		},
-
-		expandTemplates( text, title, callback ) {
-			this.api.call( {
-				action: 'expandtemplates',
-				text,
-				title,
-				generatexml: 1
-			}, function ( err, data, next, raw ) {
-				const xml = getFirstItem( raw.parsetree );
-				callback( err, xml );
-			}, 'POST' );
-		},
-
-		parse( text, title, callback ) {
-			this.api.call( {
-				action: 'parse',
-				text,
-				title,
-				contentmodel: 'wikitext',
-				generatexml: 1
-			}, function ( err, data, next, raw ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
-				const xml = getFirstItem( raw.parse.text ),
-					images = raw.parse.images;
-				callback( err, xml, images );
-			}, 'POST' );
-		},
-
-		getRecentChanges( start, callback ) {
-			const props = [
-				'title',
-				'timestamp',
-				'comments',
-				'user',
-				'flags',
-				'sizes'
-			];
-
-			this.api.call( {
-				action: 'query',
-				list: 'recentchanges',
-				rcprop: props.join( '|' ),
-				rcstart: start || '',
-				rclimit: API_LIMIT
-			}, function ( err, data, next ) {
-				callback( err, ( ( data && data.recentchanges ) || [] ), ( ( next && next.rcstart ) || false ) );
-			} );
-		},
-
-		getSiteInfo( props, callback ) {
-			// @see http://www.mediawiki.org/wiki/API:Siteinfo
-			if ( typeof props === 'string' ) {
-				props = [ props ];
-			}
-
-			this.api.call( {
-				action: 'query',
-				meta: 'siteinfo',
-				siprop: props.join( '|' )
-			}, function ( err, data ) {
-				callback( err, data );
-			} );
-		},
-
-		getSiteStats( callback ) {
-			const prop = 'statistics';
-
-			this.getSiteInfo( prop, function ( err, info ) {
-				callback( err, info && info[ prop ] );
-			} );
-		},
-
-		getMediaWikiVersion( callback ) {
-			// cache it for each instance of the client
-			// we will call it multiple times for features detection
-			if ( typeof this._mwVersion !== 'undefined' ) { // eslint-disable-line no-underscore-dangle
-				callback( null, this._mwVersion ); // eslint-disable-line no-underscore-dangle
+		// @see http://www.mediawiki.org/wiki/API:Upload
+		this.getToken( `File:${filename}`, 'edit', function ( err, token ) {
+			if ( err ) {
+				callback( err );
 				return;
 			}
 
-			this.getSiteInfo( [ 'general' ], ( ( err, info ) => {
-				let version;
+			self.log( 'Uploading %s kB as File:%s...', ( content.length / 1024 ).toFixed( 2 ), filename );
 
-				if ( err ) {
-					callback( err );
-					return;
-				}
-
-				version = info && info.general && info.general.generator; // e.g. "MediaWiki 1.27.0-wmf.19"
-				version = version.match( /[\d.]+/ )[ 0 ]; // 1.27.0
-
-				this.log( 'Detected MediaWiki v%s', version );
-
-				// cache it
-				this._mwVersion = version; // eslint-disable-line no-underscore-dangle
-				callback( null, this._mwVersion ); // eslint-disable-line no-underscore-dangle
-			} ) );
-		},
-
-		getQueryPage( queryPage, callback ) {
-			// @see http://www.mediawiki.org/wiki/API:Querypage
-			this.api.call( {
-				action: 'query',
-				list: 'querypage',
-				qppage: queryPage,
-				qplimit: API_LIMIT
-			}, ( err, data ) => {
-				if ( !err && data && data.querypage ) {
-					this.log( '%s data was generated %s', queryPage, data.querypage.cachedtimestamp );
-					callback( null, data.querypage.results || [] );
+			params.token = token;
+			self.api.call( params, function ( err, data ) {
+				if ( data && data.result && data.result === 'Success' ) {
+					self.log( 'Uploaded as <%s>', data.imageinfo.descriptionurl );
+					callback( null, data );
 				} else {
-					callback( err, [] );
+					callback( err );
 				}
-			} );
-		},
+			}, 'UPLOAD' /* fake method to set a proper content type for file uploads */ );
+		} );
+	},
 
-		upload( filename, content, extraParams, callback ) {
-			let self = this,
-				params = {
-					action: 'upload',
-					ignorewarnings: '',
-					filename,
-					file: ( typeof content === 'string' ) ? new Buffer( content, 'binary' ) : content,
-					text: ''
-				};
+	uploadByUrl( filename, url, summary, callback ) {
+		const self = this;
 
-			if ( this.dryRun ) {
-				callback( new Error( 'In dry-run mode' ) );
+		this.api.fetchUrl( url, function ( error, content ) {
+			if ( error ) {
+				callback( error, content );
 				return;
 			}
 
-			if ( typeof extraParams === 'object' ) {
-				params = _.extend( params, extraParams );
-			} else { // it's summary (comment)
-				params.comment = extraParams;
-			}
+			self.upload( filename, content, summary, callback );
+		}, 'binary' /* use binary-safe fetch */ );
+	},
 
-			// @see http://www.mediawiki.org/wiki/API:Upload
-			this.getToken( `File:${filename}`, 'edit', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
+	// Wikia-specific API entry-point
+	uploadVideo( fileName, url, callback ) {
+		const self = this,
+			parseVideoUrl = require( './utils' ).parseVideoUrl,
+			parsed = parseVideoUrl( url );
 
-				self.log( 'Uploading %s kB as File:%s...', ( content.length / 1024 ).toFixed( 2 ), filename );
+		if ( parsed === null ) {
+			callback( new Error( 'Not supported URL provided' ) );
+			return;
+		}
 
-				params.token = token;
-				self.api.call( params, function ( err, data ) {
-					if ( data && data.result && data.result === 'Success' ) {
-						self.log( 'Uploaded as <%s>', data.imageinfo.descriptionurl );
-						callback( null, data );
-					} else {
-						callback( err );
-					}
-				}, 'UPLOAD' /* fake method to set a proper content type for file uploads */ );
-			} );
-		},
+		let provider = parsed[ 0 ], videoId = parsed[ 1 ];
 
-		uploadByUrl( filename, url, summary, callback ) {
-			const self = this;
-
-			this.api.fetchUrl( url, function ( error, content ) {
-				if ( error ) {
-					callback( error, content );
-					return;
-				}
-
-				self.upload( filename, content, summary, callback );
-			}, 'binary' /* use binary-safe fetch */ );
-		},
-
-		// Wikia-specific API entry-point
-		uploadVideo( fileName, url, callback ) {
-			const self = this,
-				parseVideoUrl = require( './utils' ).parseVideoUrl,
-				parsed = parseVideoUrl( url );
-
-			if ( parsed === null ) {
-				callback( new Error( 'Not supported URL provided' ) );
+		this.getToken( `File:${fileName}`, 'edit', function ( err, token ) {
+			if ( err ) {
+				callback( err );
 				return;
 			}
 
-			let provider = parsed[ 0 ], videoId = parsed[ 1 ];
+			self.log( 'Uploading <%s> (%s provider with video ID %s)', url, provider, videoId );
 
-			this.getToken( `File:${fileName}`, 'edit', function ( err, token ) {
-				if ( err ) {
-					callback( err );
-					return;
-				}
+			self.api.call( {
+				action: 'addmediapermanent',
+				title: fileName,
+				provider: provider,
+				videoId: videoId,
+				token: token
+			}, callback, 'POST' /* The addmediapermanent module requires a POST request */ );
+		} );
+	},
 
-				self.log( 'Uploading <%s> (%s provider with video ID %s)', url, provider, videoId );
+	getExternalLinks( title, callback ) {
+		this.api.call( {
+			action: 'query',
+			prop: 'extlinks',
+			titles: title,
+			ellimit: API_LIMIT
+		}, function ( err, data ) {
+			callback( err, ( data && getFirstItem( data.pages ).extlinks ) || [] );
+		} );
+	},
 
-				self.api.call( {
-					action: 'addmediapermanent',
-					title: fileName,
-					provider: provider,
-					videoId: videoId,
-					token: token
-				}, callback, 'POST' /* The addmediapermanent module requires a POST request */ );
-			} );
-		},
+	getBacklinks( title, callback ) {
+		this.api.call( {
+			action: 'query',
+			list: 'backlinks',
+			blnamespace: 0,
+			bltitle: title,
+			bllimit: API_LIMIT
+		}, function ( err, data ) {
+			callback( err, ( data && data.backlinks ) || [] );
+		} );
+	},
 
-		getExternalLinks( title, callback ) {
-			this.api.call( {
-				action: 'query',
-				prop: 'extlinks',
-				titles: title,
-				ellimit: API_LIMIT
-			}, function ( err, data ) {
-				callback( err, ( data && getFirstItem( data.pages ).extlinks ) || [] );
-			} );
-		},
+	// utils section
+	getTemplateParamFromXml( tmplXml, paramName ) {
+		paramName = paramName
+			.trim()
+			.replace( '-', '\\-' );
 
-		getBacklinks( title, callback ) {
-			this.api.call( {
-				action: 'query',
-				list: 'backlinks',
-				blnamespace: 0,
-				bltitle: title,
-				bllimit: API_LIMIT
-			}, function ( err, data ) {
-				callback( err, ( data && data.backlinks ) || [] );
-			} );
-		},
+		const re = new RegExp( `<part><name>${paramName}\\s*</name>=<value>([^>]+)</value>` ),
+			matches = tmplXml.match( re );
 
-		// utils section
-		getTemplateParamFromXml( tmplXml, paramName ) {
-			paramName = paramName
-				.trim()
-				.replace( '-', '\\-' );
+		return matches && matches[ 1 ].trim() || false;
+	},
 
-			const re = new RegExp( `<part><name>${paramName}\\s*</name>=<value>([^>]+)</value>` ),
-				matches = tmplXml.match( re );
+	fetchUrl( url, callback, encoding ) {
+		this.api.fetchUrl( url, callback, encoding );
+	},
 
-			return matches && matches[ 1 ].trim() || false;
-		},
+	diff( prev, current ) {
+		let colors = require( 'ansicolors' ),
+			jsdiff = require( 'diff' ),
+			diff = jsdiff.diffChars( prev, current ),
+			res = '';
 
-		fetchUrl( url, callback, encoding ) {
-			this.api.fetchUrl( url, callback, encoding );
-		},
+		diff.forEach( function ( part ) {
+			const color = part.added ? 'green' :
+				part.removed ? 'red' : 'brightBlack';
 
-		diff( prev, current ) {
-			let colors = require( 'ansicolors' ),
-				jsdiff = require( 'diff' ),
-				diff = jsdiff.diffChars( prev, current ),
-				res = '';
+			res += colors[ color ]( part.value );
+		} );
 
-			diff.forEach( function ( part ) {
-				const color = part.added ? 'green' :
-					part.removed ? 'red' : 'brightBlack';
+		return res;
+	}
+};
 
-				res += colors[ color ]( part.value );
-			} );
+// Wikia-specific methods (issue #56)
+// @see http://www.wikia.com/api/v1
+Bot.prototype.wikia = {
+	API_PREFIX: '/api/v1',
 
-			return res;
+	call( path, params, callback ) {
+		let url = this.api.protocol + '://' + this.api.server + this.wikia.API_PREFIX + path;
+
+		if ( typeof params === 'function' ) {
+			callback = params;
+			this.log( 'Wikia API call:', path );
+		} else if ( typeof params === 'object' ) {
+			url += `?${querystring.stringify( params )}`;
+			this.log( 'Wikia API call:', path, params );
 		}
-	};
 
-	// Wikia-specific methods (issue #56)
-	// @see http://www.wikia.com/api/v1
-	bot.prototype.wikia = {
-		API_PREFIX: '/api/v1',
+		this.fetchUrl( url, function ( err, res ) {
+			const data = JSON.parse( res );
+			callback( err, data );
+		} );
+	},
 
-		call( path, params, callback ) {
-			let url = this.api.protocol + '://' + this.api.server + this.wikia.API_PREFIX + path;
+	getWikiVariables( callback ) {
+		this.call( '/Mercury/WikiVariables', function ( err, res ) {
+			callback( err, res.data );
+		} );
+	},
 
-			if ( typeof params === 'function' ) {
-				callback = params;
-				this.log( 'Wikia API call:', path );
-			} else if ( typeof params === 'object' ) {
-				url += `?${querystring.stringify( params )}`;
-				this.log( 'Wikia API call:', path, params );
-			}
+	getUser( ids, callback ) {
+		this.getUsers( [ ids ], function ( err, users ) {
+			callback( err, users && users[ 0 ] );
+		} );
+	},
 
-			this.fetchUrl( url, function ( err, res ) {
-				const data = JSON.parse( res );
-				callback( err, data );
-			} );
-		},
+	getUsers( ids, callback ) {
+		this.call( '/User/Details', {
+			ids: ids.join( ',' ),
+			size: 50
+		}, function ( err, res ) {
+			callback( err, res.items );
+		} );
+	}
+};
 
-		getWikiVariables( callback ) {
-			this.call( '/Mercury/WikiVariables', function ( err, res ) {
-				callback( err, res.data );
-			} );
-		},
-
-		getUser( ids, callback ) {
-			this.getUsers( [ ids ], function ( err, users ) {
-				callback( err, users && users[ 0 ] );
-			} );
-		},
-
-		getUsers( ids, callback ) {
-			this.call( '/User/Details', {
-				ids: ids.join( ',' ),
-				size: 50
-			}, function ( err, res ) {
-				callback( err, res.items );
-			} );
-		}
-	};
-
-	return bot;
-}() );
+module.exports = Bot;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,138 +4,29 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
-      "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "7.0.0-beta.46"
-      }
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
+      "dev": true
     },
-    "@babel/generator": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
-      "integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.46",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
-      "integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.46",
-        "@babel/template": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
-      "integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.46"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
-      "integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.46"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
-      "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
-      }
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
-      "integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "babylon": "7.0.0-beta.46",
-        "lodash": "^4.2.0"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
-      "integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.46",
-        "@babel/generator": "7.0.0-beta.46",
-        "@babel/helper-function-name": "7.0.0-beta.46",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.46",
-        "@babel/types": "7.0.0-beta.46",
-        "babylon": "7.0.0-beta.46",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
-      }
-    },
-    "@babel/types": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
-      "integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@types/babel-traverse": {
-      "version": "6.25.3",
-      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
-      "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
-      "dev": true,
-      "requires": {
-        "@types/babel-types": "*"
-      }
-    },
-    "@types/babel-types": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.2.tgz",
-      "integrity": "sha512-ylggu8DwwxT6mk3jVoJeohWAePWMNWEYm06MSoJ19kwp3hT9eY2Z4NNZn3oevzgFmClgNQ2GQF500hPDvNsGHg==",
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
-      "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.0.3"
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
     },
     "ajv": {
       "version": "5.5.2",
@@ -148,23 +39,37 @@
         "json-schema-traverse": "^0.3.0"
       }
     },
-    "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
-    },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "ansicolors": {
       "version": "0.3.2",
@@ -180,27 +85,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -213,6 +97,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.1",
@@ -236,12 +126,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "babylon": {
-      "version": "7.0.0-beta.46",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
-      "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -268,19 +152,10 @@
         "concat-map": "0.0.1"
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "caseless": {
@@ -289,34 +164,14 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "chardet": {
@@ -325,19 +180,13 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -352,12 +201,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -401,6 +250,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "csv-string": {
@@ -423,12 +280,12 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "deep-is": {
@@ -436,21 +293,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -463,9 +305,9 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -481,6 +323,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -488,94 +336,96 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
-      "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^4.0.0",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.12.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.0",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^4.0.3",
-        "text-table": "^0.2.0"
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.0.0"
+            "@babel/highlight": "^7.8.3"
           }
         },
         "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+          "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
           "dev": true,
           "requires": {
+            "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
             "js-tokens": "^4.0.0"
           }
         },
         "ajv": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
         },
         "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
           "dev": true
         },
         "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
         },
         "js-tokens": {
           "version": "4.0.0",
@@ -588,19 +438,68 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
         }
       }
     },
     "eslint-config-wikimedia": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.8.1.tgz",
-      "integrity": "sha512-OZek/p8znJuYoSlGR1S01ANOKQ5jRgMmgbtKnwERw6xfdykweGYoEz7FHRNWs4hTfi/RpquV88L4rbFOPR1zoQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.15.1.tgz",
+      "integrity": "sha512-Q7bpGBIzOqXmPEh4R5zgIDGZepCji77YHOWZT++U4P+tgbs0DisDwgP6krn7pPt3E7tc7L6876PpU1g0JQhAcw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^6.8.0",
+        "eslint-plugin-json": "^2.1.1",
+        "eslint-plugin-mediawiki": "^0.2.1",
+        "eslint-plugin-no-jquery": "^2.3.2",
+        "eslint-plugin-qunit": "^4.0.0"
+      }
+    },
+    "eslint-plugin-json": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-2.1.1.tgz",
+      "integrity": "sha512-Ktsab8ij33V2KFLhh4alC1FYztdmbV32DeMZYYUCZm4kKLW1s4DrleKKgtbAHSJsmshCK5QGOZtfyc2r3jCRsg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "vscode-json-languageservice": "^3.5.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-mediawiki": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mediawiki/-/eslint-plugin-mediawiki-0.2.2.tgz",
+      "integrity": "sha512-5fJ2v7td5Lktr/HB3H4ERqSbUoH2guVhQX9h8T4z7YaSqdGSNgjQcZzrVGE5rE2/EF54UpyTao2tCZSlbTRqHg==",
+      "dev": true
+    },
+    "eslint-plugin-no-jquery": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-jquery/-/eslint-plugin-no-jquery-2.3.2.tgz",
+      "integrity": "sha512-8M9GByb/JOO+dktgbFeC/YAMaqlscInO3fH3A9fLxZduH1NTXsIAUrimas6zDwOLBvEXpRaEZycc2QAl+W+Agw==",
+      "dev": true
+    },
+    "eslint-plugin-qunit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-4.0.0.tgz",
+      "integrity": "sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==",
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -608,49 +507,29 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
-    },
-    "esnext": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/esnext/-/esnext-3.3.1.tgz",
-      "integrity": "sha512-hMlaFOLLFgCpi9E08z8sLAW1QtLP8vz4siUefTu8vhHNr1DtbE/gTqkpjU8kMnGNvSSHOlZJDQSkz3tvbzCpDQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.0.0-beta.42",
-        "@babel/types": "^7.0.0-beta.42",
-        "@types/babel-traverse": "^6.7.17",
-        "babylon": "^7.0.0-beta.42",
-        "magic-string": "^0.22.2",
-        "mkdirp": "^0.5.1",
-        "shebang-regex": "^2.0.0",
-        "strip-indent": "^2.0.0"
-      },
-      "dependencies": {
-        "shebang-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-2.0.0.tgz",
-          "integrity": "sha1-9QC/aFG2E1YjYWfeLMMZsP1/BoE=",
-          "dev": true
-        }
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
     "espree": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
-      "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^5.6.0",
-        "acorn-jsx": "^4.1.1"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -660,12 +539,20 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
@@ -678,15 +565,15 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "extend": {
@@ -695,9 +582,9 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -732,35 +619,39 @@
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
       }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -811,31 +702,14 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "globals": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
-      "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "is-glob": "^4.0.1"
       }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -882,6 +756,16 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -905,75 +789,118 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^3.0.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.10",
-        "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.1.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-typedarray": {
@@ -992,16 +919,10 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1013,12 +934,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
-    },
-    "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1040,6 +955,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1067,24 +988,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0"
-      }
-    },
-    "magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-      "dev": true,
-      "requires": {
-        "vlq": "^0.2.2"
-      }
-    },
     "mime-db": {
       "version": "1.36.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
@@ -1099,9 +1002,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -1114,30 +1017,30 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "natural-compare": {
@@ -1162,12 +1065,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1178,26 +1075,26 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-tmpdir": {
@@ -1206,16 +1103,19 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -1229,33 +1129,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1263,9 +1136,9 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "psl": {
@@ -1284,9 +1157,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "regexpp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
-      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "request": {
@@ -1316,54 +1189,60 @@
         "uuid": "^3.3.2"
       }
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
-      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -1380,9 +1259,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
     "shebang-command": {
@@ -1401,25 +1280,29 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1449,66 +1332,99 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
       }
     },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-      "dev": true
-    },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
       "dev": true
     },
-    "table": {
-      "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
-      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "ajv": "^6.0.1",
-        "ajv-keywords": "^3.0.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
         },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "json-schema-traverse": {
@@ -1516,6 +1432,23 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
         }
       }
     },
@@ -1540,12 +1473,6 @@
         "os-tmpdir": "~1.0.2"
       }
     },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -1555,16 +1482,10 @@
         "punycode": "^1.4.1"
       }
     },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
       "dev": true
     },
     "tunnel-agent": {
@@ -1589,6 +1510,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "underscore": {
       "version": "1.9.1",
@@ -1617,6 +1544,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -1626,12 +1559,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
-      "dev": true
     },
     "vows": {
       "version": "0.8.2",
@@ -1651,6 +1578,43 @@
           "dev": true
         }
       }
+    },
+    "vscode-json-languageservice": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.5.2.tgz",
+      "integrity": "sha512-9cUvBq00O08lpWVVOx6tQ1yLxCHss79nsUdEAVYGomRyMbnPBmc0AkYPcXI9WK1EM6HBo0R9Zo3NjFhcICpy4A==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^2.2.1",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-nls": "^4.1.1",
+        "vscode-uri": "^2.1.1"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
+      "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+      "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
+      "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
@@ -1681,10 +1645,10 @@
         }
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wrappy": {
@@ -1694,9 +1658,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.2",
   "author": "macbre <maciej.brencz@gmail.com> (http://macbre.net)",
   "description": "MediaWiki API client written in node.js",
-  "main": "./lib/bot",
+  "main": "./lib/bot.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/macbre/nodemw.git"
@@ -37,7 +37,7 @@
     "vows": "^0.8.2"
   },
   "scripts": {
-    "test": "vows --spec",
+    "test": "vows --spec && eslint .",
     "lint": "eslint ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "BSD",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=10.0"
   },
   "dependencies": {
     "ansicolors": "0.3.x",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
   },
   "devDependencies": {
     "csv-string": "^3.1.5",
-    "eslint": "^5.6.0",
-    "eslint-config-wikimedia": "^0.8.1",
-    "esnext": "^3.3.1",
+    "eslint-config-wikimedia": "^0.15.1",
     "vows": "^0.8.2"
   },
   "scripts": {


### PR DESCRIPTION
### Add Node 12 testing, discontinue Node 8 and earlier

* The Node 4 LTS reached end-of-life in April 2018.
* The Node 6 LTS reached end-of-life in April 2019.
* The Node 8 LTS reached enf-of-life in December 2019.

<https://nodejs.org/en/about/releases/>
<https://github.com/nodejs/Release#end-of-life-releases>

This is done as preparation before other contributions I plan to make to update dependencies (some of which no longer support older versions), and some simplifications (some of which would
require additional packages be added to support older versions).

The previous versions of this package naturally conitinue to be available for those using them on older Node.js versions, and in the event of a critical bug we could even create an v0.x-release" branch or something and create a new patch release from there against the older code.

-------

### Minor CI changes

* Remove 'sudo: false'. This was to make Travis use a fast container,  instead of a VM. But, this option no longer exits.   Travis now always uses a VM, and they're relatively fast.

* Use 'cache: npm'.

  This repo has package-lock.json, which is great! (thank you).   When package-lock.json exists, the installer deletes node_modules   completely and rebuilds it fresh, based on the lock file.
  During local development, this is very fast because npm also has a   cache at $HOME/.npm (which is not deleted).

  The 'cache: npm' shortcut will cache "$HOME/.npm" instead of   "node_modules". Otherwise, this directory is copied by Travis   from the cache but then immediately deleted by npm-install/npm-ci.

  <https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#caching-with-npm>

* Make 'npm test' include lint checks.

  This project uses ESLint and it can be run manually via 'npm run lint'.   It is also run automatically by Travis.

  Make ESLint also executed by default when developers run 'npm test'   locally. That makes it easier to contribute by not having to learn   about lint issues after submitting a patch, and not having to read   .travis.yaml or package.json in detail.

