### PR TITLE
Use arrow functions to preserve lexical 'this' instead of 'self'

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -13,18 +13,17 @@ const async = require( 'async' );
 const request = require( 'request' );
 
 function doRequest( params, callback, method, done ) {
-	const self = this,
-		// store requested action - will be used when parsing a response
-		actionName = params.action,
-		// "request" options
-		options = {
-			method: method || 'GET',
-			proxy: this.proxy || false,
-			jar: this.jar,
-			headers: {
-				'User-Agent': this.userAgent
-			}
-		};
+	// store requested action - will be used when parsing a response
+	const actionName = params.action;
+	// "request" options
+	const options = {
+		method: method || 'GET',
+		proxy: this.proxy || false,
+		jar: this.jar,
+		headers: {
+			'User-Agent': this.userAgent
+		}
+	};
 
 	// HTTP request parameters
 	params = params || {};
@@ -48,13 +47,13 @@ function doRequest( params, callback, method, done ) {
 			postBody.push( CRLF );
 
 			if ( typeof value === 'string' ) {
-			// properly encode UTF8 in binary-safe POST data
+				// properly encode UTF8 in binary-safe POST data
 				postBody.push( `Content-Disposition: form-data; name="${fieldName}"` );
 				postBody.push( CRLF );
 				postBody.push( CRLF );
 				postBody.push( Buffer.from( value, 'utf8' ) );
 			} else {
-			// send attachment
+				// send attachment
 				postBody.push( `Content-Disposition: form-data; name="${fieldName}"; filename="foo"` );
 				postBody.push( CRLF );
 				postBody.push( CRLF );
@@ -93,21 +92,21 @@ function doRequest( params, callback, method, done ) {
 		this.logger.debug( 'POST fields: %s', Object.keys( options.form ).join( ', ' ) );
 	}
 
-	request( options, function ( error, response, body ) {
+	request( options, ( error, response, body ) => {
 		response = response || {};
 
 		if ( error ) {
-			self.logger.error( 'Request to API failed: %s', error );
+			this.logger.error( 'Request to API failed: %s', error );
 			callback( new Error( `Request to API failed: ${error}` ) );
 			done();
 			return;
 		}
 
 		if ( response.statusCode !== 200 ) {
-			self.logger.error( 'Request to API failed: HTTP status code was %d for <%s>', response.statusCode || 'unknown', options.url );
-			self.logger.debug( 'Body: %s', body );
+			this.logger.error( 'Request to API failed: HTTP status code was %d for <%s>', response.statusCode || 'unknown', options.url );
+			this.logger.debug( 'Body: %s', body );
 
-			self.logger.data( new Error().stack );
+			this.logger.data( new Error().stack );
 
 			callback( new Error( `Request to API failed: HTTP status code was ${response.statusCode}` ) );
 			done();
@@ -135,8 +134,8 @@ function doRequest( params, callback, method, done ) {
 				next = data && data.continue;
 			}
 		} catch ( e ) {
-			self.logger.error( 'Error parsing JSON response: %s', body );
-			self.logger.data( body );
+			this.logger.error( 'Error parsing JSON response: %s', body );
+			this.logger.data( body );
 
 			callback( new Error( 'Error parsing JSON response' ) );
 			done();
@@ -147,14 +146,14 @@ function doRequest( params, callback, method, done ) {
 
 		if ( data && !data.error ) {
 			if ( next ) {
-				self.logger.debug( 'There\'s more data' );
-				self.logger.debug( next );
+				this.logger.debug( 'There\'s more data' );
+				this.logger.debug( next );
 			}
 
 			callback( null, info, next, data );
 		} else if ( data.error ) {
-			self.logger.error( 'Error returned by API: %s', data.error.info );
-			self.logger.data( data.error );
+			this.logger.error( 'Error returned by API: %s', data.error.info );
+			this.logger.data( data.error );
 
 			callback( new Error( `Error returned by API: ${data.error.info}` ) );
 		}
@@ -252,35 +251,34 @@ Api.prototype = {
 
 	// fetch an external resource
 	fetchUrl( url, callback, encoding ) {
-		const self = this;
 		encoding = encoding || 'utf-8';
 
 		// add a request to the queue
-		this.queue.push( function ( done ) {
-			self.info( 'Fetching <%s> (as %s)...', url, encoding );
+		this.queue.push( ( done ) => {
+			this.info( 'Fetching <%s> (as %s)...', url, encoding );
 
 			const options = {
 				url,
 				method: 'GET',
-				proxy: self.proxy || false,
-				jar: self.jar,
+				proxy: this.proxy || false,
+				jar: this.jar,
 				encoding: ( encoding === 'binary' ) ? null : encoding,
 				headers: {
-					'User-Agent': self.userAgent
+					'User-Agent': this.userAgent
 				}
 			};
 
-			request( options, function ( error, response, body ) {
+			request( options, ( error, response, body ) => {
 				if ( !error && response.statusCode === 200 ) {
-					self.info( '<%s>: fetched %s kB', url, ( body.length / 1024 ).toFixed( 2 ) );
+					this.info( '<%s>: fetched %s kB', url, ( body.length / 1024 ).toFixed( 2 ) );
 					callback( null, body );
 				} else {
 					if ( !error ) {
 						error = new Error( `HTTP status ${response.statusCode}` );
 					}
 
-					self.error( `Failed to fetch <${url}>` );
-					self.error( error.message );
+					this.error( `Failed to fetch <${url}>` );
+					this.error( error.message );
 					callback( error, body );
 				}
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -103,8 +103,7 @@ Bot.prototype = {
 	},
 
 	getAll( params, key, callback ) {
-		let self = this,
-			res = [],
+		let res = [],
 			// @see https://www.mediawiki.org/wiki/API:Query#Continuing_queries
 			continueParams = {
 				continue: ''
@@ -112,8 +111,8 @@ Bot.prototype = {
 
 		async.whilst(
 			() => true, // run as long as there's more data
-			function ( callback ) {
-				self.api.call( _.extend( params, continueParams ), function ( err, data, next ) {
+			( callback ) => {
+				this.api.call( _.extend( params, continueParams ), ( err, data, next ) => {
 					if ( err ) {
 						callback( err );
 					} else {
@@ -128,7 +127,7 @@ Bot.prototype = {
 					}
 				} );
 			},
-			function ( err ) {
+			( err ) => {
 				if ( err instanceof Error ) {
 					callback( err );
 				} else {
@@ -154,25 +153,24 @@ Bot.prototype = {
 
 		this.log( 'Obtaining login token...' );
 
-		const self = this,
-			logInCallback = function ( err, data ) {
-				if ( data === null || typeof data === 'undefined' ) {
-					self.error( 'Logging in failed: no data received' );
-					callback( err || new Error( 'Logging in failed: no data received' ) );
-				} else if ( !err && typeof data.lgusername !== 'undefined' ) {
-					self.log( `Logged in as ${data.lgusername}` );
-					callback( null, data );
-				} else if ( typeof data.reason === 'undefined' ) {
-					self.error( 'Logging in failed' );
-					self.error( data.result );
-					callback( err || new Error( `Logging in failed: ${data.result}` ) );
-				} else {
-					self.error( 'Logging in failed' );
-					self.error( data.result );
-					self.error( data.reason );
-					callback( err || new Error( `Logging in failed: ${data.result} - ${data.reason}` ) );
-				}
-			};
+		const logInCallback = ( err, data ) => {
+			if ( data === null || typeof data === 'undefined' ) {
+				this.error( 'Logging in failed: no data received' );
+				callback( err || new Error( 'Logging in failed: no data received' ) );
+			} else if ( !err && typeof data.lgusername !== 'undefined' ) {
+				this.log( `Logged in as ${data.lgusername}` );
+				callback( null, data );
+			} else if ( typeof data.reason === 'undefined' ) {
+				this.error( 'Logging in failed' );
+				this.error( data.result );
+				callback( err || new Error( `Logging in failed: ${data.result}` ) );
+			} else {
+				this.error( 'Logging in failed' );
+				this.error( data.result );
+				this.error( data.reason );
+				callback( err || new Error( `Logging in failed: ${data.result} - ${data.reason}` ) );
+			}
+		};
 
 		// request a token
 		this.api.call( {
@@ -180,7 +178,7 @@ Bot.prototype = {
 			lgname: username,
 			lgpassword: password,
 			lgdomain: domain
-		}, function ( err, data ) {
+		}, ( err, data ) => {
 			if ( err ) {
 				callback( err );
 				return;
@@ -189,10 +187,10 @@ Bot.prototype = {
 			if ( data.result === 'NeedToken' ) {
 				const token = data.token;
 
-				self.log( `Got token ${token}` );
+				this.log( `Got token ${token}` );
 
 				// log in using a token
-				self.api.call( {
+				this.api.call( {
 					action: 'login',
 					lgname: username,
 					lgpassword: password,
@@ -217,7 +215,7 @@ Bot.prototype = {
 				acprefix: prefix || '',
 				aclimit: API_LIMIT
 			},
-			( data )=>data.allcategories.map( ( cat ) => cat[ '*' ] ),
+			( data ) => data.allcategories.map( ( cat ) => cat[ '*' ] ),
 			callback
 		);
 	},
@@ -479,21 +477,19 @@ Bot.prototype = {
 
 	// this should only be used internally (see #84)
 	doEdit( type, title, summary, params, callback ) {
-		const self = this;
-
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
 			return;
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Edit
-		this.getToken( title, 'edit', function ( err, token ) {
+		this.getToken( title, 'edit', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( `Editing '${title}' with a summary '${summary}' (${type})...` );
+			this.log( `Editing '${title}' with a summary '${summary}' (${type})...` );
 
 			const editParams = _.extend( {
 				action: 'edit',
@@ -503,9 +499,9 @@ Bot.prototype = {
 				token
 			}, params );
 
-			self.api.call( editParams, function ( err, data ) {
+			this.api.call( editParams, ( err, data ) => {
 				if ( !err && data.result && data.result === 'Success' ) {
-					self.log( 'Rev #%d created for \'%s\'', data.newrevid, data.title );
+					this.log( 'Rev #%d created for \'%s\'', data.newrevid, data.title );
 					callback( null, data );
 				} else {
 					callback( err || data );
@@ -550,21 +546,19 @@ Bot.prototype = {
 	},
 
 	addFlowTopic( title, subject, content, callback ) {
-		const self = this;
-
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
 			return;
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Flow
-		this.getToken( title, 'flow', function ( err, token ) {
+		this.getToken( title, 'flow', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( `Adding a topic to page '${title}' with subject '${subject}'...` );
+			this.log( `Adding a topic to page '${title}' with subject '${subject}'...` );
 
 			const params = {
 				action: 'flow',
@@ -577,9 +571,9 @@ Bot.prototype = {
 				token: token
 			};
 
-			self.api.call( params, function ( err, data ) {
+			this.api.call( params, ( err, data ) => {
 				if ( !err && data[ 'new-topic' ] && data[ 'new-topic' ].status && data[ 'new-topic' ].status === 'ok' ) {
-					self.log( 'Workflow \'%s\' created on \'%s\'', data[ 'new-topic' ].workflow, title );
+					this.log( 'Workflow \'%s\' created on \'%s\'', data[ 'new-topic' ].workflow, title );
 					callback( null, data );
 				} else {
 					callback( err );
@@ -589,28 +583,26 @@ Bot.prototype = {
 	},
 
 	'delete'( title, reason, callback ) {
-		const self = this;
-
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
 			return;
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Delete
-		this.getToken( title, 'delete', function ( err, token ) {
+		this.getToken( title, 'delete', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( 'Deleting \'%s\' because \'%s\'...', title, reason );
+			this.log( 'Deleting \'%s\' because \'%s\'...', title, reason );
 
-			self.api.call( {
+			this.api.call( {
 				action: 'delete',
 				title,
 				reason,
 				token
-			}, function ( err, data ) {
+			}, ( err, data ) => {
 				if ( !err && data.title && data.reason ) {
 					callback( null, data );
 				} else {
@@ -622,10 +614,9 @@ Bot.prototype = {
 
 	purge( titles, callback ) {
 		// @see https://www.mediawiki.org/wiki/API:Purge
-		const self = this,
-			params = {
-				action: 'purge'
-			};
+		const params = {
+			action: 'purge'
+		};
 
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
@@ -655,11 +646,11 @@ Bot.prototype = {
 
 		this.api.call(
 			params,
-			function ( err, data ) {
+			( err, data ) => {
 				if ( !err ) {
-					data.forEach( function ( page ) {
+					data.forEach( ( page ) => {
 						if ( typeof page.purged !== 'undefined' ) {
-							self.log( 'Purged "%s"', page.title );
+							this.log( 'Purged "%s"', page.title );
 						}
 					} );
 				}
@@ -671,32 +662,30 @@ Bot.prototype = {
 	},
 
 	sendEmail( username, subject, text, callback ) {
-		const self = this;
-
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
 			return;
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Email
-		this.getToken( `User:${username}`, 'email', function ( err, token ) {
+		this.getToken( `User:${username}`, 'email', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( 'Sending an email to \'%s\' with subject \'%s\'...', username, subject );
+			this.log( 'Sending an email to \'%s\' with subject \'%s\'...', username, subject );
 
-			self.api.call( {
+			this.api.call( {
 				action: 'emailuser',
 				target: username,
 				subject,
 				text,
 				ccme: '',
 				token
-			}, function ( err, data ) {
+			}, ( err, data ) => {
 				if ( !err && data.result && data.result === 'Success' ) {
-					self.log( 'Email sent' );
+					this.log( 'Email sent' );
 					callback( null, data );
 				} else {
 					callback( err );
@@ -779,21 +768,20 @@ Bot.prototype = {
 
 	createAccount( username, password, callback ) {
 		// @see https://www.mediawiki.org/wiki/API:Account_creation
-		const self = this;
 		this.log( `creating account ${username}` );
 		this.api.call( {
 			action: 'query',
 			meta: 'tokens',
 			type: 'createaccount'
-		}, function ( err, data ) {
-			self.api.call( {
+		}, ( err, data ) => {
+			this.api.call( {
 				action: 'createaccount',
-				createreturnurl: `${self.api.protocol}://${self.api.server}:${self.api.port}/`,
+				createreturnurl: `${this.api.protocol}://${this.api.server}:${this.api.port}/`,
 				createtoken: data.tokens.createaccounttoken,
 				username: username,
 				password: password,
 				retype: password
-			}, function ( err, data ) {
+			}, ( err, data ) => {
 				if ( err ) {
 					callback( err );
 					return;
@@ -804,30 +792,28 @@ Bot.prototype = {
 	},
 
 	move( from, to, summary, callback ) {
-		const self = this;
-
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
 			return;
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Move
-		this.getToken( from, 'move', function ( err, token ) {
+		this.getToken( from, 'move', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( 'Moving \'%s\' to \'%s\' because \'%s\'...', from, to, summary );
+			this.log( 'Moving \'%s\' to \'%s\' because \'%s\'...', from, to, summary );
 
-			self.api.call( {
+			this.api.call( {
 				action: 'move',
 				from,
 				to,
 				bot: '',
 				reason: summary,
 				token
-			}, function ( err, data ) {
+			}, ( err, data ) => {
 				if ( !err && data.from && data.to && data.reason ) {
 					callback( null, data );
 				} else {
@@ -1047,14 +1033,13 @@ Bot.prototype = {
 	},
 
 	upload( filename, content, extraParams, callback ) {
-		let self = this,
-			params = {
-				action: 'upload',
-				ignorewarnings: '',
-				filename,
-				file: ( typeof content === 'string' ) ? Buffer.from( content, 'binary' ) : content,
-				text: ''
-			};
+		let params = {
+			action: 'upload',
+			ignorewarnings: '',
+			filename,
+			file: ( typeof content === 'string' ) ? Buffer.from( content, 'binary' ) : content,
+			text: ''
+		};
 
 		if ( this.dryRun ) {
 			callback( new Error( 'In dry-run mode' ) );
@@ -1068,18 +1053,18 @@ Bot.prototype = {
 		}
 
 		// @see http://www.mediawiki.org/wiki/API:Upload
-		this.getToken( `File:${filename}`, 'edit', function ( err, token ) {
+		this.getToken( `File:${filename}`, 'edit', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( 'Uploading %s kB as File:%s...', ( content.length / 1024 ).toFixed( 2 ), filename );
+			this.log( 'Uploading %s kB as File:%s...', ( content.length / 1024 ).toFixed( 2 ), filename );
 
 			params.token = token;
-			self.api.call( params, function ( err, data ) {
+			this.api.call( params, ( err, data ) => {
 				if ( data && data.result && data.result === 'Success' ) {
-					self.log( 'Uploaded as <%s>', data.imageinfo.descriptionurl );
+					this.log( 'Uploaded as <%s>', data.imageinfo.descriptionurl );
 					callback( null, data );
 				} else {
 					callback( err );
@@ -1089,23 +1074,20 @@ Bot.prototype = {
 	},
 
 	uploadByUrl( filename, url, summary, callback ) {
-		const self = this;
-
-		this.api.fetchUrl( url, function ( error, content ) {
+		this.api.fetchUrl( url, ( error, content ) => {
 			if ( error ) {
 				callback( error, content );
 				return;
 			}
 
-			self.upload( filename, content, summary, callback );
+			this.upload( filename, content, summary, callback );
 		}, 'binary' /* use binary-safe fetch */ );
 	},
 
 	// Wikia-specific API entry-point
 	uploadVideo( fileName, url, callback ) {
-		const self = this,
-			parseVideoUrl = require( './utils' ).parseVideoUrl,
-			parsed = parseVideoUrl( url );
+		const parseVideoUrl = require( './utils' ).parseVideoUrl;
+		const parsed = parseVideoUrl( url );
 
 		if ( parsed === null ) {
 			callback( new Error( 'Not supported URL provided' ) );
@@ -1114,15 +1096,15 @@ Bot.prototype = {
 
 		let provider = parsed[ 0 ], videoId = parsed[ 1 ];
 
-		this.getToken( `File:${fileName}`, 'edit', function ( err, token ) {
+		this.getToken( `File:${fileName}`, 'edit', ( err, token ) => {
 			if ( err ) {
 				callback( err );
 				return;
 			}
 
-			self.log( 'Uploading <%s> (%s provider with video ID %s)', url, provider, videoId );
+			this.log( 'Uploading <%s> (%s provider with video ID %s)', url, provider, videoId );
 
-			self.api.call( {
+			this.api.call( {
 				action: 'addmediapermanent',
 				title: fileName,
 				provider: provider,


### PR DESCRIPTION
None of the methods involved in this module make use of a custom
'this' value inside the callback, so let the same be consistently
available throughout a given method by using arrow functions.

Arrow functions, unlike regular functions, do not offer the function
its own "function" scope (with its own 'this' and 'arguments' vars),
and instead offer only a block scope.