### PR TITLE
Tests - remove Node.js 10x, add 15.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,11 +7,9 @@ on:
   push:
     branches: [ devel ]
   pull_request:
-    branches: [ devel ]
 
 jobs:
-  build:
-
+  tests:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,10 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version:
+        - "12.x"
+        - "14.x"
+        - "15.x"
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "BSD",
   "engines": {
-    "node": ">=10.0"
+    "node": ">=12.0"
   },
   "dependencies": {
     "ansicolors": "0.3.x",


### PR DESCRIPTION
https://nodejs.org/en/about/releases/ - Node.js 10.x is no longer supported since June 2020