### PR TITLE
Make npm package smaller by skipping some files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.*
+*.md
+AUTHORS
+examples/
+test/


### PR DESCRIPTION
### Before

```
$ npm publish --dry-run
npm notice package size:  28.9 kB
npm notice unpacked size: 96.8 kB
```

### After

```
npm notice package size:  14.3 kB
npm notice unpacked size: 50.0 kB
```