### PR TITLE
Fix issues with getArticleInfo

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -471,25 +471,27 @@ Bot.prototype = {
 		const params = {
 			action: 'query',
 			prop: 'info',
-			inprop: options.inprop.join( '|' )
+			inprop: options.inprop.join( '|' ),
+			titles: []
 		};
-		if ( options.intestactions.length !== 0 ) {
+
+		const titles = [];
+		if ( options.intestactions && options.intestactions.length !== 0 ) {
 			params.intestactions = options.intestactions.join( '|' );
 		}
 		if ( typeof title === 'string' ) {
-			title.push( title );
+			titles.push( title );
 		}
 		if ( typeof title === 'number' ) {
-			title.push( title );
+			titles.push( title );
 		}
 		if ( typeof title === 'object' ) {
 			let objTitle = title;
-			title = [];
 			for ( let key in objTitle ) {
-				title.push( objTitle[ key ] );
+				titles.push( objTitle[ key ] );
 			}
 		}
-		title.forEach( ( t ) => {
+		titles.forEach( ( t ) => {
 			if ( typeof t === 'string' ) {
 				params.titles.push( t );
 			}
@@ -502,7 +504,7 @@ Bot.prototype = {
 			params,
 			function ( batch ) {
 				const page = getFirstItem( batch.pages );
-				return page.revisions;
+				return page;
 			},
 			callback
 		);

--- a/test/mediawiki-api-test.js
+++ b/test/mediawiki-api-test.js
@@ -85,6 +85,21 @@ vows.describe( 'Mediawiki API' ).addBatch( {
 			assert.equal( redirectInfo.from, 'Einstein' );
 		}
 	},
+	'getArticleInfo()': {
+		topic: function () {
+			client.getArticleInfo( ARTICLE, this.callback );
+		},
+		'valid content is passed to callback': function ( e, res ) {
+			assert.isArray( res );
+			assert.isTrue( res.length === 1 );
+
+			const data = res[ 0 ];
+			assert.isNumber( data.pageid );
+			assert.isString( data.title );
+			assert.isArray( data.protection );
+			assert.isTrue( data.title.includes( 'Albert Einstein' ) );
+		}
+	},
 	'getImagesFromArticle()': {
 		topic: function () {
 			client.getImagesFromArticle( ARTICLE, this.callback );


### PR DESCRIPTION
Several issues meant this just did not work at all:

- titles was not instantiated
- options.intestactions is assumed to exist
- the page revisions were returned, instead of the full dataset.