### PR TITLE
New method getArticleProperties()

### DIFF
--- a/lib/bot.d.ts
+++ b/lib/bot.d.ts
@@ -12,6 +12,7 @@ import {
 
 	// responses typing
 	ArticleInfo,
+	ArticleProperties,
     PageEditedResult,
     PageInCategory,
 	RedirectInfo,
@@ -43,6 +44,7 @@ declare class Bot {
     edit( title: string, content: string, summary: string, minor: boolean, callback: NodeJSCallback<PageEditedResult> ): void;
     getArticle( article: string, callback: NodeJSCallback<string> ): void;
 	getArticle( article: string, followRedirect: boolean, callback: NodeJSCallbackDouble<string, RedirectInfo> ): void;
+	getArticleProperties(title: string, callback: NodeJSCallback<ArticleProperties>): void;
     getMediaWikiVersion( callback: NodeJSCallback<string> ): void;
     getPagesInCategory( category: string, callback: NodeJSCallback<PageInCategory[]>): void;
     logIn( callback: NodeJSCallback<any>): void;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -452,6 +452,32 @@ class Bot {
 		} );
 	}
 
+	getArticleProperties( title, callback ) {
+		// https://en.wikipedia.org/w/api.php?action=query&format=json&redirects=1&titles=Saksun&prop=pageprops
+		const params = {
+			action: 'query',
+			prop: 'pageprops',
+			titles: title
+		};
+
+		this.api.call( params, ( err, data ) => {
+			if ( err ) {
+				callback( err );
+				return;
+			}
+
+			/**
+			 * page_image_free: 'Einstein_1921_by_F_Schmutzer_-_restoration.jpg',
+			 * 'wikibase-badge-Q17437798': '1',
+			 * 'wikibase-shortdesc': 'German-born scientist (1879–1955)',
+			 * wikibase_item: 'Q937'
+			 */
+			const properties = getFirstItem( data.pages );
+
+			callback( err, properties.pageprops );
+		} );
+	}
+
 	getArticleInfo( title, options, callback ) {
 		if ( typeof options === 'function' ) { // This is the callback; options was nonexistant
 			callback = options;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -182,3 +182,9 @@ export interface ArticleInfo {
 	displaytitle: string;
 	varianttitles: Map<string, string>;
 }
+
+export interface ArticleProperties {
+	page_image_free: string;
+	'wikibase-shortdesc': string;
+	wikibase_item: string;
+}

--- a/test/mediawiki-api-test.js
+++ b/test/mediawiki-api-test.js
@@ -54,6 +54,16 @@ describe( 'MediaWiki API', () => {
 			done();
 		} );
 	}, 5000 );
+
+	it( 'getArticleProperties() returns article properties', ( done ) => {
+		client.getArticleProperties( TEST_ARTICLE, ( err, props ) => {
+			expect( err ).toBeNull();
+			expect( props.wikibase_item ).toEqual( 'Q937' );
+			expect( props[ 'wikibase-shortdesc' ] ).toContain( 'scientist' );
+
+			done();
+		} );
+	}, 5000 );
 } );
 
 // FIXME: use a proxy when running on CI


### PR DESCRIPTION
Example: https://en.wikipedia.org/w/api.php?action=query&format=json&redirects=1&titles=Saksun&prop=pageprops

```yaml
$ curl -s 'https://en.wikipedia.org/w/api.php?action=query&format=json&redirects=1&titles=Saksun&prop=pageprops'  | jq '.query.pages."5696731".pageprops'
{
  "page_image_free": "Saksun,_Faroe_Islands_(2).JPG",
  "wikibase-shortdesc": "Village in Faroe Islands, Kingdom of Denmark",
  "wikibase_item": "Q928875"
}

```