### PR TITLE
CI - updated the list of Node.js versions to test against

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,11 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # https://github.com/nodejs/release#release-schedule
         node-version:
-        - "14.x"
-        - "16.x"
-        - "17.x"
-        - '18.x'
+        - "14.x"  # maintenance
+        - "16.x"  # maintenance
+        - '18.x'  # LTS
+        - '19.x'  # current
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
According to https://github.com/nodejs/release#release-schedule:

* 17.x is no longer supported
* 19.x added as the current version
* 14.x & 16.x have a maintenance status