### PR TITLE
CI: do not hardcode Node.js version - use the "latest" and "lts/*"

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         # https://github.com/nodejs/release#release-schedule
+        # https://github.com/actions/setup-node#supported-version-syntax
         node-version:
-        - "16.x"  # maintenance
-        - '18.x'  # LTS
-        - '20.x'  # current
+        - "latest"
+        - "current"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,8 +17,8 @@ jobs:
         # https://github.com/nodejs/release#release-schedule
         # https://github.com/actions/setup-node#supported-version-syntax
         node-version:
+        - "stable"
         - "latest"
-        - "current"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
         # https://github.com/nodejs/release#release-schedule
         # https://github.com/actions/setup-node#supported-version-syntax
         node-version:
-        - "stable"
+        - "lts/*"
         - "latest"
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,6 +29,9 @@ jobs:
         cache: npm
         node-version: ${{ matrix.node-version }}
 
+    - name: Log the Node.js version used
+      run: echo "::notice::Using Node.js $( node -v)"
+
     - name: Install dependencies
       run: npm ci
 


### PR DESCRIPTION
Currently that's Node.js 18.x and 20.x

```
$ nvm list | grep 'lts/\*'
lts/* -> lts/hydrogen (-> v18.17.1)
```

> tests (lts/*)
> Using Node.js v18.17.1
>
> tests (latest)
> Using Node.js v20.6.0
