### PR TITLE
Fix the Bot.getTemplateParamFromXml() helper for newer MediaWiki versions

### DIFF
--- a/lib/bot.d.ts
+++ b/lib/bot.d.ts
@@ -146,7 +146,10 @@ declare class Bot {
   getQueryPage(queryPage: any, callback: NodeJSCallback<any>): void;
   getRand(): void;
   getRecentChanges(start: any, callback: NodeJSCallback<any>): void;
-  getTemplateParamFromXml(tmplXml: any, paramName: any): void;
+  getTemplateParamFromXml(
+    tmplXml: string,
+    paramName: string,
+  ): string | undefined;
   getToken(title: any, action: any, callback: NodeJSCallback<any>): void;
   getUsers(data: any, callback: NodeJSCallback<any>): void;
   move(from: any, to: any, summary: any, callback: NodeJSCallback<any>): void;

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1536,16 +1536,27 @@ class Bot {
     );
   }
 
-  // utils section
+  //
+  // Utils section
+  //
+  /**
+   * Returns the provided parameter value from the template invocation XML structure.
+   * Use Bot.expandTemplates() to get the XML representation of the template invocation wikitext.
+   *
+   * @param {string} tmplXml
+   * @param {string} paramName
+   * @returns {string|undefined}
+   */
   getTemplateParamFromXml(tmplXml, paramName) {
     paramName = paramName.trim().replace("-", "\\-");
 
+    // e.g. </title><part><name>lat</name><equals>=</equals><value>52.3162771
     const re = new RegExp(
-        `<part><name>${paramName}\\s*</name>=<value>([^>]+)</value>`,
+        `<part><name>${paramName}\\s*</name><equals>=</equals><value>([^>]+)</value>`,
       ),
       matches = tmplXml.match(re);
 
-    return (matches && matches[1].trim()) || false;
+    return (matches && matches[1].trim()) || undefined;
   }
 
   fetchUrl(url, callback, encoding) {

--- a/test/bot-test.js
+++ b/test/bot-test.js
@@ -79,3 +79,29 @@ describe("Bot.diff", () => {
     expect(diff).toContain("bar");
   });
 });
+
+describe("Bot.getTemplateParamFromXml", () => {
+  const client = new Bot(__dirname + "/config.json");
+
+  it("returns arguments", () => {
+    const templateXml = `
+<template lineStart="1"><title>Place
+</title><part><name>lat</name><equals>=</equals><value>52.3162771
+</value></part><part><name>lon</name><equals>=</equals><value>16.8823280
+</value></part><part><name>width</name><equals>=</equals><value>300
+</value></part><part><name>zoom</name><equals>=</equals><value>13
+</value></part><part><name>name</name><equals>=</equals><value>ąęófoo
+</value></part></template>`;
+
+    expect(client.getTemplateParamFromXml(templateXml, "foo")).toBeUndefined();
+    expect(client.getTemplateParamFromXml(templateXml, "lat")).toStrictEqual(
+      "52.3162771",
+    );
+    expect(client.getTemplateParamFromXml(templateXml, "zoom")).toStrictEqual(
+      "13",
+    );
+    expect(client.getTemplateParamFromXml(templateXml, "name")).toStrictEqual(
+      "ąęófoo",
+    );
+  });
+});


### PR DESCRIPTION
```xml
<template lineStart="1"><title>Place
</title><part><name>lat</name><equals>=</equals><value>52.3162771
</value></part><part><name>lon</name><equals>=</equals><value>16.8823280
</value></part><part><name>width</name><equals>=</equals><value>300
</value></part><part><name>zoom</name><equals>=</equals><value>13
</value></part><part><name>name</name><equals>=</equals><value>ąęófoo
</value></part></template>
```

`=` part is now wrapped inside `<equals>` tags.