### PR TITLE
Update api.js and bot.js: supporting custom referer header

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -22,6 +22,7 @@ function doRequest(params, callback, method, done) {
     jar: this.jar,
     headers: {
       "User-Agent": this.userAgent,
+      "Referer": this.referer
     },
   };
 
@@ -225,10 +226,17 @@ function Api(options) {
     options.userAgent ||
     `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})`;
   this.version = VERSION;
+  this.referer = options.referer || this.formatUrl({
+    protocol: this.protocol,
+    port: this.port,
+    hostname: this.server,
+    pathname: this.path + "/api.php"
+  });
 
   // debug info
   this.info(process.argv.join(" "));
   this.info(this.userAgent);
+  this.info(this.referer)
 
   let port = this.port ? `:${this.port}` : "";
 
@@ -279,6 +287,7 @@ Api.prototype = {
         encoding: encoding === "binary" ? null : encoding,
         headers: {
           "User-Agent": this.userAgent,
+          
         },
       };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -22,7 +22,7 @@ function doRequest(params, callback, method, done) {
     jar: this.jar,
     headers: {
       "User-Agent": this.userAgent,
-      "Referer": this.referer
+      Referer: this.referer,
     },
   };
 
@@ -221,23 +221,24 @@ function Api(options) {
 
   // HTTP client
   this.formatUrl = require("url").format;
-  
-  this.referer = options.referer || this.formatUrl({
-    protocol: this.protocol,
-    port: this.port,
-    hostname: this.server,
-    pathname: this.path + "/api.php"
-  });
+
+  this.referer =
+    options.referer ||
+    this.formatUrl({
+      protocol: this.protocol,
+      port: this.port,
+      hostname: this.server,
+      pathname: this.path + "/api.php",
+    });
   this.userAgent =
     options.userAgent ||
     `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})`;
   this.version = VERSION;
 
-
   // debug info
   this.info(process.argv.join(" "));
   this.info(this.userAgent);
-  this.info(this.referer)
+  this.info(this.referer);
 
   let port = this.port ? `:${this.port}` : "";
 
@@ -288,7 +289,6 @@ Api.prototype = {
         encoding: encoding === "binary" ? null : encoding,
         headers: {
           "User-Agent": this.userAgent,
-          
         },
       };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -221,17 +221,18 @@ function Api(options) {
 
   // HTTP client
   this.formatUrl = require("url").format;
-
-  this.userAgent =
-    options.userAgent ||
-    `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})`;
-  this.version = VERSION;
+  
   this.referer = options.referer || this.formatUrl({
     protocol: this.protocol,
     port: this.port,
     hostname: this.server,
     pathname: this.path + "/api.php"
   });
+  this.userAgent =
+    options.userAgent ||
+    `nodemw/${VERSION} (node.js ${process.version}; ${process.platform} ${process.arch})`;
+  this.version = VERSION;
+
 
   // debug info
   this.info(process.argv.join(" "));

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -67,6 +67,7 @@ class Bot {
       path: options.path || "",
       proxy: options.proxy,
       userAgent: options.userAgent,
+      referer: options.referer,
       concurrency: options.concurrency,
       debug: options.debug === true || env.DEBUG === "1",
     });

--- a/test/bot-test.js
+++ b/test/bot-test.js
@@ -35,14 +35,13 @@ describe("Bot", () => {
     expect(client.api.userAgent).toEqual("foo/bar 1.2.3");
   });
 
-  it("supports a custom referer", () =>{
+  it("supports a custom referer", () => {
     const client = new Bot({
-      referer: "https://wiki.example.com/"
+      referer: "https://wiki.example.com/",
     });
 
     expect(client.api.referer).toEqual("https://wiki.example.com/");
   });
-
 });
 
 describe("Bot.config", () => {

--- a/test/bot-test.js
+++ b/test/bot-test.js
@@ -34,6 +34,15 @@ describe("Bot", () => {
 
     expect(client.api.userAgent).toEqual("foo/bar 1.2.3");
   });
+
+  it("supports a custom referer", () =>{
+    const client = new Bot({
+      referer: "https://wiki.example.com/"
+    });
+
+    expect(client.api.referer).toEqual("https://wiki.example.com/");
+  });
+
 });
 
 describe("Bot.config", () => {


### PR DESCRIPTION
A new parameter added to allow users specify a custom referer. This option is inspired by [WikiFur](https://wikifur.com/), a wiki site that applied referer checking on **API endpoints** (it seems ridiculous):
```bash
# Node.js network inspection for failed request, in curl format
curl -v -H 'user-agent: nodemw/0.24.1 (node.js v22.17.0; win32 x64)' -H 'host: zh.wikifur.com' -H 'cookie: zh_session=[redacted for privacy]' 'http://zh.wikifur.com/w/api.php?action=query&prop=info&intoken=edit&titles=[redacted for privacy]&format=json'
< HTTP 403
< date: Thu, 30 Oct 2025 02:59:26 GMT
< server: Apache/2.4.65 (FreeBSD)
< content-length: 199
< connection: close
< content-type: text/html; charset=iso-8859-1
<
```
Referer checking is obviously performed by Apache.

Adding referer header to api call within my fork solves this problem. It was originally a small hack, but I finally made it standarized, wrote a test case for it and it passed.