### PR TITLE
`fetchurl-test` seems to fail on fetching from example.com, use github.com instead

### DIFF
--- a/test/fetchurl-test.js
+++ b/test/fetchurl-test.js
@@ -10,9 +10,9 @@ describe("fetchUrl", () => {
   });
 
   it("passes page content to a callback", (done) => {
-    client.fetchUrl("https://example.com", (err, res) => {
+    client.fetchUrl("https://github.com/macbre/nodemw", (err, res) => {
       expect(err).toBeNull();
-      expect(res).toContain("<h1>Example Domain</h1>");
+      expect(res).toContain("macbre/nodemw</h1>");
 
       done();
     });


### PR DESCRIPTION
```
fetchUrl › passes page content to a callback

    thrown: "Exceeded timeout of 5000 ms for a test while waiting for `done()` to be called.

Received: [Error: unable to get local issuer certificate]
    at toBeNull (test/fetchurl-test.js:14:19)
```