### PR TITLE
Tests now use bot account

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -42,6 +42,9 @@ jobs:
       run: npx prettier --check .
 
     - name: Run the tests
+      env:
+        TEST_BOT_USERNAME: ${{ secrets.TEST_BOT_USERNAME }}
+        TEST_BOT_PASSWORD: ${{ secrets.TEST_BOT_PASSWORD }}
       run: npm test
 
     # https://github.com/marketplace/actions/coveralls-github-action

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ npm-debug.log
 config.js
 .eslintcache
 coverage
+.env

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Or [Download the latest stable version](https://github.com/macbre/nodemw/release
 git clone https://github.com/macbre/nodemw.git
 ```
 
+> [!NOTE]
+> To run integration tests against production Wikipedia and WikiData servers,
+> you first need to reate your own bot account at <https://test.wikipedia.org/wiki/Special:BotPasswords>.
+>
+> And then set the `TEST_BOT_USERNAME` and `TEST_BOT_PASSWORD` env variables when running tests.
+> Otherwise, we're getting rate-limited (HTTP 429 responses).
+>
+> CI checks are already set up.
+
 ## Features
 
 - HTTP requests are stored in the queue and performed in parallel with limited number of "threads" (i.e. there's no risk of flooding the server)

--- a/lib/api.js
+++ b/lib/api.js
@@ -113,7 +113,7 @@ function doRequest(params, callback, method, done) {
         response.statusCode || "unknown",
         options.url,
       );
-      this.logger.debug("Body: %s", body);
+      this.logger.debug(`Body: ${body}`);
       this.logger.error("Stacktrace", new Error().stack);
 
       callback(

--- a/lib/wikidata.js
+++ b/lib/wikidata.js
@@ -8,7 +8,7 @@
 
 const Api = require("./api");
 
-const WIKIDATA_SERVER = "wikidata.org";
+const WIKIDATA_SERVER = "www.wikidata.org";
 const WIKIDATA_PATH = "/w";
 const WIKIDATA_USER_AGENT = "nodemw";
 
@@ -30,6 +30,7 @@ class WikiData {
   constructor() {
     this.api = new Api({
       server: WIKIDATA_SERVER,
+      protocol: "https",
       path: WIKIDATA_PATH,
       userAgent: WIKIDATA_USER_AGENT,
       debug: process.env.DEBUG === "1",
@@ -40,8 +41,9 @@ class WikiData {
    * Promisified wrapper around Node.js-style callbacks from nodemw api class
    *
    * @param {Object} params
+   * @param {string} method (default to GET)
    */
-  async callApi(params) {
+  async callApi(params, method) {
     return new Promise((resolve, reject) => {
       this.api.call(
         {
@@ -56,6 +58,7 @@ class WikiData {
             resolve(data);
           }
         },
+        method,
       );
     });
   }
@@ -148,6 +151,50 @@ class WikiData {
   async getEntityClaim(entity, claim) {
     const claims = await this.getEntityClaims(entity);
     return claims[claim] ?? null;
+  }
+
+  /**
+   * @param {string} username
+   * @param {string}  password
+   * @returns {Promise<void>}
+   */
+  async logIn(username, password) {
+    // username and password params can be omitted
+    if (typeof username !== "string") {
+      // use data from config
+      username = this.options.username;
+      password = this.options.password;
+    }
+
+    // First, we need to get a login token.
+    // Fetching a token via "action=login" is deprecated. Use "action=query&meta=tokens&type=login" instead.
+    const tokenResp = await this.callApi(
+      { action: "query", meta: "tokens", type: "login" },
+      "POST",
+    );
+
+    /**
+     * token {
+     *       batchcomplete: '',
+     *       query: {
+     *         tokens: { logintoken: 'foo-bar' }
+     *       }
+     *     }
+     */
+    const lgtoken = tokenResp?.query?.tokens?.logintoken || undefined;
+
+    // Now, log in using a token
+    const res = await this.callApi(
+      { action: "login", lgname: username, lgpassword: password, lgtoken },
+      "POST",
+    );
+
+    // { result: 'Success', lguserid: 2205543, lgusername: 'McBre' }
+    if (res.login?.result !== "Success") {
+      throw new Error(`Login failed: ${res.login?.result}`);
+    }
+
+    return res.login;
   }
 }
 

--- a/test/mediawiki-api-test.js
+++ b/test/mediawiki-api-test.js
@@ -1,7 +1,14 @@
 "use strict";
 
-const { describe, it, expect } = require("@jest/globals");
+const { beforeAll, describe, it, expect } = require("@jest/globals");
 const Bot = require("..");
+const { env } = require("node:process");
+
+// Create your own bot account at https://test.wikipedia.org/wiki/Special:BotPasswords
+// Add set these env variables when running tests.
+// Otherwise, we're getting rate-limited (HTTP 429 responses).
+const TEST_BOT_USERNAME = env["TEST_BOT_USERNAME"];
+const TEST_BOT_PASSWORD = env["TEST_BOT_PASSWORD"];
 
 describe("MediaWiki API", () => {
   const client = new Bot({
@@ -11,6 +18,16 @@ describe("MediaWiki API", () => {
   });
   const TEST_ARTICLE = "Albert Einstein";
   const TEST_ARTICLE_REDIRECT = "Einstein";
+
+  if (!TEST_BOT_USERNAME) {
+    it.skip("Suite skipped as it requires a test account", () => {});
+    return;
+  }
+
+  beforeAll((done) => {
+    client.log("Logging in using a test account " + TEST_BOT_USERNAME);
+    client.logIn(TEST_BOT_USERNAME, TEST_BOT_PASSWORD, done);
+  });
 
   it("siteinfo()", (done) => {
     client.getSiteInfo(["general"], (err, info) => {
@@ -70,16 +87,7 @@ describe("MediaWiki API", () => {
   }, 5000);
 });
 
-// FIXME: use a proxy when running on CI
 describe("Bot on test.wikipedia.org", () => {
-  if (process.env.CI === "true") {
-    it.skip(
-      "GitHub Actions are blocked by Wikipedia for anon traffic",
-      it.todo,
-    );
-    return;
-  }
-
   const client = new Bot({
     protocol: "https",
     server: "test.wikipedia.org",
@@ -92,6 +100,16 @@ describe("Bot on test.wikipedia.org", () => {
     .slice(2)} --~~~~`;
 
   let lastRevisionId;
+
+  if (!TEST_BOT_USERNAME) {
+    it.skip("Suite skipped as it requires a test account", () => {});
+    return;
+  }
+
+  beforeAll((done) => {
+    client.log("Logging in using a test account " + TEST_BOT_USERNAME);
+    client.logIn(TEST_BOT_USERNAME, TEST_BOT_PASSWORD, done);
+  });
 
   it("can make edits to <https://test.wikipedia.org/wiki/NodeMW_client>", (done) => {
     client.edit(

--- a/test/wikidata-test.js
+++ b/test/wikidata-test.js
@@ -1,8 +1,15 @@
 // @ts-check
 "use strict";
 
-const { describe, it, expect } = require("@jest/globals");
+const { describe, it, expect, beforeAll } = require("@jest/globals");
 const WikiData = require("../lib/wikidata");
+const { env } = require("node:process");
+
+// Create your own bot account at https://test.wikipedia.org/wiki/Special:BotPasswords
+// Add set these env variables when running tests.
+// Otherwise, we're getting rate-limited (HTTP 429 responses).
+const TEST_BOT_USERNAME = env["TEST_BOT_USERNAME"];
+const TEST_BOT_PASSWORD = env["TEST_BOT_PASSWORD"];
 
 describe("WikiData API", () => {
   const TEST_ARTICLE = "Albert Einstein"; // https://www.wikidata.org/wiki/Q937
@@ -11,6 +18,15 @@ describe("WikiData API", () => {
   const NOT_EXISTING_ENTITY = "Q3976321987569386512312";
 
   const client = new WikiData();
+
+  if (!TEST_BOT_USERNAME) {
+    it.skip("Suite skipped as it requires a test account", () => {});
+    return;
+  }
+
+  beforeAll(async () => {
+    await client.logIn(TEST_BOT_USERNAME, TEST_BOT_PASSWORD);
+  });
 
   describe("getArticleSitelinks()", () => {
     it(`returns sitelinks for "${TEST_ARTICLE}" article`, async () => {


### PR DESCRIPTION
Running CI checks using anon requests triggers rate-limiting on Wikimedia servers.

Be a decent citizen and log in using the bot account. More instructions in the `README` file.