### PR TITLE
`fetchurl-test`: use example.com instead of github.com

### DIFF
--- a/test/fetchurl-test.js
+++ b/test/fetchurl-test.js
@@ -10,9 +10,9 @@ describe("fetchUrl", () => {
   });
 
   it("passes page content to a callback", (done) => {
-    client.fetchUrl("https://github.com/macbre/nodemw", (err, res) => {
+    client.fetchUrl("https://example.com", (err, res) => {
       expect(err).toBeNull();
-      expect(res).toContain("macbre/nodemw</h1>");
+      expect(res).toContain("Example Domain");
 
       done();
     });


### PR DESCRIPTION
Fixes:

```
  ● fetchUrl › passes page content to a callback

    thrown: "Exceeded timeout of 5000 ms for a test while waiting for `done()` to be called.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

      10 |   });
      11 |
    > 12 |   it("passes page content to a callback", (done) => {
         |   ^
      13 |     client.fetchUrl("https://github.com/macbre/nodemw", (err, res) => {
      14 |       expect(err).toBeNull();
      15 |       expect(res).toContain("macbre/nodemw</h1>");

      at it (test/fetchurl-test.js:12:3)
      at Object.describe (test/fetchurl-test.js:6:1)
```